### PR TITLE
chore: helper functions for JSON value reading/extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 example/test.txt
+.DS_Store

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -28,6 +28,7 @@ use serde_json::Value;
 use tokio::fs::File;
 
 use crate::{
+    jsonmap,
     model::{
         account_service::ManagerAccount,
         certificate::Certificate,
@@ -377,36 +378,9 @@ impl Redfish for Bmc {
         let disabled = EnabledDisabled::Disabled.to_string();
 
         // BMC lockdown
-
         let (attrs, url) = self.manager_attributes().await?;
-
-        let key = "Lockdown.1.SystemLockdown";
-        let system_lockdown = attrs
-            .get(key)
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: key.to_string(),
-                url: url.to_string(),
-            })?
-            .as_str()
-            .ok_or_else(|| RedfishError::InvalidKeyType {
-                key: key.to_string(),
-                expected_type: "&str".to_string(),
-                url: url.to_string(),
-            })?;
-
-        let key = "Racadm.1.Enable";
-        let racadm = attrs
-            .get(key)
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: key.to_string(),
-                url: url.to_string(),
-            })?
-            .as_str()
-            .ok_or_else(|| RedfishError::InvalidKeyType {
-                key: key.to_string(),
-                expected_type: "&str".to_string(),
-                url: url.to_string(),
-            })?;
+        let system_lockdown = jsonmap::get_str(&attrs, "Lockdown.1.SystemLockdown", &url)?;
+        let racadm = jsonmap::get_str(&attrs, "Racadm.1.Enable", &url)?;
 
         message.push_str(&format!(
             "BMC: system_lockdown={system_lockdown}, racadm={racadm}."
@@ -802,35 +776,11 @@ impl Redfish for Bmc {
         let url = format!("Managers/iDRAC.Embedded.1/Jobs/{}", job_id);
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
-        let job_state_key = "JobState";
-        let job_state_value = body
-            .get(job_state_key)
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: job_state_key.to_string(),
-                url: url.to_string(),
-            })?
-            .as_str()
-            .ok_or_else(|| RedfishError::InvalidKeyType {
-                key: job_state_key.to_string(),
-                expected_type: "&str".to_string(),
-                url: url.to_string(),
-            })?;
+        let job_state_value = jsonmap::get_str(&body, "JobState", &url)?;
 
         let job_state = match JobState::from_str(job_state_value) {
             JobState::Scheduled => {
-                let message_key = "Message";
-                let message_value = body
-                    .get(message_key)
-                    .ok_or_else(|| RedfishError::MissingKey {
-                        key: message_key.to_string(),
-                        url: url.to_string(),
-                    })?
-                    .as_str()
-                    .ok_or_else(|| RedfishError::InvalidKeyType {
-                        key: message_key.to_string(),
-                        expected_type: "&str".to_string(),
-                        url: url.to_string(),
-                    })?;
+                let message_value = jsonmap::get_str(&body, "Message", &url)?;
                 match message_value {
                     /* Example JSON response body for a job that is Scheduled but will never complete: the job remains stuck in a Scheduled state indefinitely.
                     {
@@ -981,24 +931,11 @@ impl Redfish for Bmc {
     }
 
     async fn is_infinite_boot_enabled(&self) -> Result<Option<bool>, RedfishError> {
+        let url = format!("Systems/{}/Bios", self.s.system_id());
         let bios = self.bios().await?;
-        let bios_attributes = match bios.get("Attributes") {
-            Some(attributes) => attributes,
-            None => {
-                return Err(RedfishError::MissingKey {
-                    key: "Attributes".to_owned(),
-                    url: format!("Systems/{}/Bios", self.s.system_id()),
-                })
-            }
-        };
-
-        let infinite_boot_status = bios_attributes
-            .get("BootSeqRetry")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: "BootSeqRetry".to_string(),
-                url: "Bios attributes".to_string(),
-            })?;
+        let bios_attributes = jsonmap::get_object(&bios, "Attributes", &url)?;
+        let infinite_boot_status =
+            jsonmap::get_str(bios_attributes, "BootSeqRetry", "Bios Attributes")?;
 
         Ok(Some(
             infinite_boot_status == EnabledDisabled::Enabled.to_string(),
@@ -1295,23 +1232,10 @@ impl Bmc {
         self.s.client.post(&url, body).await.map(|_resp| ())
     }
 
-    // Is system lockdown enabled?
+    // is_lockdown checks if system lockdown is enabled.
     async fn is_lockdown(&self) -> Result<bool, RedfishError> {
         let (attrs, url) = self.manager_attributes().await?;
-
-        let key = "Lockdown.1.SystemLockdown";
-        let system_lockdown = attrs
-            .get(key)
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: key.to_string(),
-                url: url.to_string(),
-            })?
-            .as_str()
-            .ok_or_else(|| RedfishError::InvalidKeyType {
-                key: key.to_string(),
-                expected_type: "&str".to_string(),
-                url: url.to_string(),
-            })?;
+        let system_lockdown = jsonmap::get_str(&attrs, "Lockdown.1.SystemLockdown", &url)?;
 
         let enabled = EnabledDisabled::Enabled.to_string();
         Ok(system_lockdown == enabled)
@@ -1519,18 +1443,7 @@ impl Bmc {
         let mut enabled = true;
         let mut disabled = true;
         for (key, val_enabled, val_disabled) in expected {
-            let val_current = attrs
-                .get(key)
-                .ok_or_else(|| RedfishError::MissingKey {
-                    key: key.to_string(),
-                    url: url.to_string(),
-                })?
-                .as_str()
-                .ok_or_else(|| RedfishError::InvalidKeyType {
-                    key: key.to_string(),
-                    expected_type: "&str".to_string(),
-                    url: url.to_string(),
-                })?;
+            let val_current = jsonmap::get_str(&attrs, key, url)?;
             message.push_str(&format!("{key}={val_current} "));
             if val_current != val_enabled {
                 enabled = false;
@@ -1678,29 +1591,17 @@ impl Bmc {
         Ok(log_entries)
     }
 
-    // Second value in tuple is URL we used to fetch attributes, for diagnostics
+    // manager_attributes fetches Dell manager attributes and returns them as a JSON Map.
+    // Second value in tuple is URL we used to fetch attributes, for diagnostics.
     async fn manager_attributes(
         &self,
     ) -> Result<(serde_json::Map<String, serde_json::Value>, String), RedfishError> {
         let manager_id = self.s.manager_id();
-        let url = &format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
+        let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
         let (_status_code, mut body): (_, HashMap<String, serde_json::Value>) =
-            self.s.client.get(url).await?;
-        let key = "Attributes";
-        let v = match body.remove(key).ok_or_else(|| RedfishError::MissingKey {
-            key: key.to_string(),
-            url: url.to_string(),
-        })? {
-            serde_json::Value::Object(obj) => obj,
-            _ => {
-                return Err(RedfishError::InvalidKeyType {
-                    key: key.to_string(),
-                    expected_type: "Object".to_string(),
-                    url: url.to_string(),
-                });
-            }
-        };
-        Ok((v, url.to_string()))
+            self.s.client.get(&url).await?;
+        let attrs = jsonmap::extract_object(&mut body, "Attributes", &url)?;
+        Ok((attrs, url))
     }
 
     /// Extra Dell-specific attributes we need to set that are not BIOS attributes
@@ -2058,14 +1959,7 @@ impl Bmc {
         let url = format!("Systems/System.Embedded.1/Storage/{controller_id}");
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
-
-        let key = "Drives";
-        body.get(key)
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: key.to_string(),
-                url: url.to_string(),
-            })
-            .cloned()
+        jsonmap::get_value(&body, "Drives", &url).cloned()
     }
 
     async fn create_storage_volume(

--- a/src/jsonmap.rs
+++ b/src/jsonmap.rs
@@ -1,0 +1,290 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// jsonmap.rs
+// This provides helper functions for extracting values from JSON maps,
+// which as you can imagine happens a lot in a Redfish library.
+
+use std::any::type_name;
+use std::collections::HashMap;
+
+use serde::de::DeserializeOwned;
+
+use crate::RedfishError;
+
+// JsonMap is a trait that abstracts over serde_json::Map and HashMap,
+// allowing us to write generic functions that work with both.
+pub trait JsonMap {
+    // get_value retrieves a reference to a JSON value by key.
+    fn get_value(&self, key: &str) -> Option<&serde_json::Value>;
+
+    // remove_value removes and returns a JSON value by key.
+    fn remove_value(&mut self, key: &str) -> Option<serde_json::Value>;
+}
+
+// Implement JsonMap for JSON maps.
+impl JsonMap for serde_json::Map<String, serde_json::Value> {
+    fn get_value(&self, key: &str) -> Option<&serde_json::Value> {
+        self.get(key)
+    }
+
+    fn remove_value(&mut self, key: &str) -> Option<serde_json::Value> {
+        self.remove(key)
+    }
+}
+
+// Implement JsonMap for HashMaps.
+impl JsonMap for HashMap<String, serde_json::Value> {
+    fn get_value(&self, key: &str) -> Option<&serde_json::Value> {
+        self.get(key)
+    }
+
+    fn remove_value(&mut self, key: &str) -> Option<serde_json::Value> {
+        self.remove(key)
+    }
+}
+
+// missing_key_error creates a RedfishError::MissingKey error.
+fn missing_key_error(key: &str, url: &str) -> RedfishError {
+    RedfishError::MissingKey {
+        key: key.to_string(),
+        url: url.to_string(),
+    }
+}
+
+// invalid_type_error creates a RedfishError::InvalidKeyType error.
+fn invalid_type_error(key: &str, expected_type: &str, url: &str) -> RedfishError {
+    RedfishError::InvalidKeyType {
+        key: key.to_string(),
+        expected_type: expected_type.to_string(),
+        url: url.to_string(),
+    }
+}
+
+// get_value retrieves a JSON value from a map, returning MissingKey
+// error if the key is not found. This is useful for directly fetching
+// a raw Value for further processing, or for callers who want to
+// fetch a value and attempt to convert it to a specific type.
+pub fn get_value<'a, M: JsonMap>(
+    map: &'a M,
+    key: &str,
+    url: &str,
+) -> Result<&'a serde_json::Value, RedfishError> {
+    map.get_value(key)
+        .ok_or_else(|| missing_key_error(key, url))
+}
+
+// get_str extracts a string value from a JSON map, returning appropriate
+// errors if the key is missing or the value is not a string.
+pub fn get_str<'a, M: JsonMap>(map: &'a M, key: &str, url: &str) -> Result<&'a str, RedfishError> {
+    get_value(map, key, url)?
+        .as_str()
+        .ok_or_else(|| invalid_type_error(key, "string", url))
+}
+
+// get_object extracts an object (Map) from a JSON map, returning
+// appropriate errors if the key is missing or the value is not an object.
+pub fn get_object<'a, M: JsonMap>(
+    map: &'a M,
+    key: &str,
+    url: &str,
+) -> Result<&'a serde_json::Map<String, serde_json::Value>, RedfishError> {
+    get_value(map, key, url)?
+        .as_object()
+        .ok_or_else(|| invalid_type_error(key, "object", url))
+}
+
+// get_bool extracts a boolean value from a JSON map, returning
+// appropriate errors if the key is missing or the value is not a boolean.
+pub fn get_bool<M: JsonMap>(map: &M, key: &str, url: &str) -> Result<bool, RedfishError> {
+    get_value(map, key, url)?
+        .as_bool()
+        .ok_or_else(|| invalid_type_error(key, "boolean", url))
+}
+
+// get_i64 extracts an integer value from a JSON map, returning
+// appropriate errors if the key is missing or the value is not an integer.
+#[allow(dead_code)]
+pub fn get_i64<M: JsonMap>(map: &M, key: &str, url: &str) -> Result<i64, RedfishError> {
+    get_value(map, key, url)?
+        .as_i64()
+        .ok_or_else(|| invalid_type_error(key, "integer", url))
+}
+
+// get_f64 extracts a floating-point value from a JSON map, returning
+// appropriate errors if the key is missing or the value is not a number.
+#[allow(dead_code)]
+pub fn get_f64<M: JsonMap>(map: &M, key: &str, url: &str) -> Result<f64, RedfishError> {
+    get_value(map, key, url)?
+        .as_f64()
+        .ok_or_else(|| invalid_type_error(key, "number", url))
+}
+
+// extract removes a key from a map and deserializes the
+// value to type T. Returns an error if the key is missing or
+// deserialization fails.
+pub fn extract<T, M: JsonMap>(map: &mut M, key: &str, url: &str) -> Result<T, RedfishError>
+where
+    T: DeserializeOwned,
+{
+    let json = map
+        .remove_value(key)
+        .ok_or_else(|| missing_key_error(key, url))?;
+    serde_json::from_value::<T>(json).map_err(|_| invalid_type_error(key, type_name::<T>(), url))
+}
+
+// extract_object removes a key from a HashMap and returns it
+// as a JSON Map. Returns an error if the key is missing or the
+// value is not an object.
+pub fn extract_object<M: JsonMap>(
+    map: &mut M,
+    key: &str,
+    url: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, RedfishError> {
+    extract(map, key, url).map_err(|e| match e {
+        RedfishError::InvalidKeyType { key, url, .. } => invalid_type_error(&key, "object", &url),
+        e => e,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // test_get_str_success tests that get_str correctly extracts a string value.
+    #[test]
+    fn test_get_str_success() {
+        let value = json!({
+            "Name": "TestName",
+            "Id": "123"
+        });
+        let map = value.as_object().unwrap();
+
+        let result = get_str(map, "Name", "http://test/url");
+        assert_eq!(result.unwrap(), "TestName");
+    }
+
+    // test_get_str_with_hashmap tests that get_str works with HashMap.
+    #[test]
+    fn test_get_str_with_hashmap() {
+        let mut map: HashMap<String, serde_json::Value> = HashMap::new();
+        map.insert("Name".to_string(), json!("TestName"));
+
+        let result = get_str(&map, "Name", "http://test/url");
+        assert_eq!(result.unwrap(), "TestName");
+    }
+
+    // test_get_str_missing_key tests that get_str returns MissingKey error when key doesn't exist.
+    #[test]
+    fn test_get_str_missing_key() {
+        let value = json!({
+            "Name": "TestName"
+        });
+        let map = value.as_object().unwrap();
+
+        let result = get_str(map, "Missing", "http://test/url");
+        assert!(matches!(result, Err(RedfishError::MissingKey { .. })));
+    }
+
+    // test_get_str_wrong_type tests that get_str returns InvalidKeyType when value is not a string.
+    #[test]
+    fn test_get_str_wrong_type() {
+        let value = json!({
+            "Count": 42
+        });
+        let map = value.as_object().unwrap();
+
+        let result = get_str(map, "Count", "http://test/url");
+        assert!(matches!(result, Err(RedfishError::InvalidKeyType { .. })));
+    }
+
+    // test_get_object_success tests that get_object correctly extracts an object.
+    #[test]
+    fn test_get_object_success() {
+        let value = json!({
+            "Nested": {
+                "Inner": "value"
+            }
+        });
+        let map = value.as_object().unwrap();
+
+        let result = get_object(map, "Nested", "http://test/url");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap().get("Inner").unwrap().as_str().unwrap(),
+            "value"
+        );
+    }
+
+    // test_get_bool_success tests that get_bool correctly extracts a boolean value.
+    #[test]
+    fn test_get_bool_success() {
+        let value = json!({
+            "Enabled": true,
+            "Disabled": false
+        });
+        let map = value.as_object().unwrap();
+
+        assert_eq!(get_bool(map, "Enabled", "http://test/url").unwrap(), true);
+        assert_eq!(get_bool(map, "Disabled", "http://test/url").unwrap(), false);
+    }
+
+    // test_get_i64_success tests that get_i64 correctly extracts an integer value.
+    #[test]
+    fn test_get_i64_success() {
+        let value = json!({
+            "Count": 42
+        });
+        let map = value.as_object().unwrap();
+
+        assert_eq!(get_i64(map, "Count", "http://test/url").unwrap(), 42);
+    }
+
+    // test_extract_success tests that extract correctly extracts and
+    // removes a value.
+    #[test]
+    fn test_extract_success() {
+        let mut map: HashMap<String, serde_json::Value> = HashMap::new();
+        map.insert("Name".to_string(), json!("TestName"));
+
+        let result: Result<String, _> = extract(&mut map, "Name", "http://test/url");
+        assert_eq!(result.unwrap(), "TestName");
+        assert!(map.is_empty());
+    }
+
+    // test_extract_object_success tests extract_object with a HashMap.
+    #[test]
+    fn test_extract_object_success() {
+        let mut map: HashMap<String, serde_json::Value> = HashMap::new();
+        map.insert("Nested".to_string(), json!({"Inner": "value"}));
+
+        let result = extract_object(&mut map, "Nested", "http://test/url");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap().get("Inner").unwrap().as_str().unwrap(),
+            "value"
+        );
+        assert!(map.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 mod dell;
 mod error;
 mod hpe;
+pub mod jsonmap;
 mod lenovo;
 mod network;
 mod nvidia_dpu;

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -40,6 +40,7 @@ use crate::model::task::Task;
 use crate::model::thermal::Fan;
 use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
 use crate::{
+    jsonmap,
     model::{
         boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
@@ -1262,35 +1263,32 @@ impl Bmc {
         Ok(bios_attrs)
     }
 
-    // Get the current status of the EmbeddedUefiShell BIOS attribute
+    // get_embedded_uefi_shell_status returns the current status of the EmbeddedUefiShell BIOS attribute.
     async fn get_embedded_uefi_shell_status(&self) -> Result<EnabledDisabled, RedfishError> {
-        if let Some(bios_attributes) = self.s.bios_attributes().await?.as_object() {
-            let embedded_uefi_shell = bios_attributes
-                .get("EmbeddedUefiShell")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| RedfishError::MissingKey {
-                    key: "EmbeddedUefiShell".to_string(),
-                    url: format!("Systems/{}/Bios", self.s.system_id()),
+        let url = format!("Systems/{}/Bios", self.s.system_id());
+        let bios_value = self.s.bios_attributes().await?;
+        let bios_attributes =
+            bios_value
+                .as_object()
+                .ok_or_else(|| RedfishError::InvalidKeyType {
+                    key: "Attributes".to_string(),
+                    expected_type: "object".to_string(),
+                    url: url.clone(),
                 })?;
 
-            match embedded_uefi_shell {
-                "Enabled" => Ok(EnabledDisabled::Enabled),
-                "Disabled" => Ok(EnabledDisabled::Disabled),
-                _ => Err(RedfishError::InvalidValue {
-                    url: format!("Systems/{}/Bios", self.s.system_id()),
-                    field: "EmbeddedUefiShell".to_string(),
-                    err: crate::model::InvalidValueError(format!(
-                        "Expected 'Enabled' or 'Disabled', got '{}'",
-                        embedded_uefi_shell
-                    )),
-                }),
-            }
-        } else {
-            Err(RedfishError::InvalidKeyType {
-                key: "Attributes".to_string(),
-                expected_type: "Object".to_string(),
-                url: format!("Systems/{}/Bios", self.s.system_id()),
-            })
+        let embedded_uefi_shell = jsonmap::get_str(bios_attributes, "EmbeddedUefiShell", &url)?;
+
+        match embedded_uefi_shell {
+            "Enabled" => Ok(EnabledDisabled::Enabled),
+            "Disabled" => Ok(EnabledDisabled::Disabled),
+            _ => Err(RedfishError::InvalidValue {
+                url,
+                field: "EmbeddedUefiShell".to_string(),
+                err: crate::model::InvalidValueError(format!(
+                    "Expected 'Enabled' or 'Disabled', got '{}'",
+                    embedded_uefi_shell
+                )),
+            }),
         }
     }
 }

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -46,6 +46,7 @@ use crate::model::{sel::LogEntry, ManagerResetType};
 use crate::model::{sel::LogEntryCollection, serial_interface::SerialInterface};
 use crate::model::{storage::Drives, storage::Storage};
 use crate::network::{RedfishHttpClient, REDFISH_ENDPOINT};
+use crate::{jsonmap, BootOptions, Collection, PCIeDevice, RedfishError, Resource};
 use crate::{
     model, BiosProfileType, Boot, EnabledDisabled, JobState, NetworkDeviceFunction, NetworkPort,
     PowerState, Redfish, RoleId, Status, Systems,
@@ -54,7 +55,6 @@ use crate::{
     model::chassis::{Chassis, NetworkAdapter},
     MachineSetupStatus,
 };
-use crate::{BootOptions, Collection, PCIeDevice, RedfishError, Resource};
 
 const UEFI_PASSWORD_NAME: &str = "AdministratorPassword";
 
@@ -934,18 +934,7 @@ impl RedfishStandard {
         url: &str,
         mut body: HashMap<String, serde_json::Value>,
     ) -> Result<Vec<String>, RedfishError> {
-        let key = "Members";
-        let members_json = body.remove(key).ok_or_else(|| RedfishError::MissingKey {
-            key: key.to_string(),
-            url: url.to_string(),
-        })?;
-        let Ok(members) = serde_json::from_value::<Vec<ODataId>>(members_json) else {
-            return Err(RedfishError::InvalidKeyType {
-                key: key.to_string(),
-                expected_type: "Vec<ODataId>".to_string(),
-                url: url.to_string(),
-            });
-        };
+        let members: Vec<ODataId> = jsonmap::extract(&mut body, "Members", url)?;
         let member_ids: Vec<String> = members
             .into_iter()
             .filter_map(|d| d.odata_id_get().map(|id| id.to_string()).ok())
@@ -1141,40 +1130,25 @@ impl RedfishStandard {
         Ok(member)
     }
 
-    // BIOS attributes that will be applied on next restart
+    // pending_attributes returns BIOS attributes that will be applied on next restart.
     pub async fn pending_attributes(
         &self,
         pending_url: &str,
     ) -> Result<serde_json::Map<String, serde_json::Value>, RedfishError> {
         let (_sc, mut body): (reqwest::StatusCode, HashMap<String, serde_json::Value>) =
             self.client.get(pending_url).await?;
-        let mut attrs = body
-            .remove("Attributes")
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: "Attributes".to_string(),
-                url: pending_url.to_string(),
-            })?;
-        let attrs_map = match attrs.as_object_mut() {
-            Some(m) => m,
-            None => {
-                return Err(RedfishError::InvalidKeyType {
-                    key: "Attributes".to_string(),
-                    expected_type: "Map".to_string(),
-                    url: pending_url.to_string(),
-                })
-            }
-        };
-        Ok(core::mem::take(attrs_map))
+        jsonmap::extract_object(&mut body, "Attributes", pending_url)
     }
 
-    // Current BIOS attributes
+    // bios_attributes returns the current BIOS attributes.
     pub async fn bios_attributes(&self) -> Result<serde_json::Value, RedfishError> {
+        let url = format!("Systems/{}/Bios", self.system_id());
         let mut b = self.bios().await?;
 
         b.remove("Attributes")
             .ok_or_else(|| RedfishError::MissingKey {
                 key: "Attributes".to_string(),
-                url: format!("Systems/{}/Bios", self.system_id()),
+                url,
             })
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -806,4 +806,3 @@ fn get_tmp_dir() -> PathBuf {
     let temp_dir = format!("{}-{}-{}", PYTHON_VENV_DIR, std::process::id(), nanos);
     env::temp_dir().join(&temp_dir)
 }
-


### PR DESCRIPTION
This creates a new `jsonmap.rs` module with generic helper functions to read and extract values from JSON objects. It defines a `JsonMap` trait which has support for both `serde_json::Map` and `HashMap`, making it so call sites can just call `jsonmap::${fn}`.

The reason behind this is there was tons of repetitive, boilerplate code where we would repeatedly attempt to:
- Read a key from a map.
- Error if it wasn't found.
- Convert the key to the correct type.
- Error if it failed.
- Return the value.

This cleans up all of that by:
- Creating functions that work with our new `JsonMap` trait.
- Turning those 26 call sites of repetitive code into 1 liners.

**Exmple before:**
```
let system_lockdown = attrs
    .get(key)
    .ok_or_else(|| RedfishError::MissingKey {
        key: key.to_string(),
        url: url.to_string(),
    })?
    .as_str()
    .ok_or_else(|| RedfishError::InvalidKeyType {
        key: key.to_string(),
        expected_type: "&str".to_string(),
        url: url.to_string(),
    })?;
```

**Example after:**
```
let system_lockdown = jsonmap::get_str(&attrs, "Lockdown.1.SystemLockdown", &url)?;
```

The `JsonMap` trait is a really basic trait which abstracts over map types, and provides an interface for fetching and removal/extraction (which is another thing we do in a number of places in the codebase).

```
pub trait JsonMap {
    fn get_value(&self, key: &str) -> Option<&serde_json::Value>;
    fn remove_value(&mut self, key: &str) -> Option<serde_json::Value>;
}
```

I also added some small wrappers for error creation to further simplify how the functions read:
```
fn missing_key_error(key: &str, url: &str) -> RedfishError { ... }
fn invalid_type_error(key: &str, expected_type: &str, url: &str) -> RedfishError { ... }
```

And then pulled it all together with this PR.