### PR TITLE
chore: replace unwrap calls with safer/cleaner alternatives

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1921,10 +1921,14 @@ impl Bmc {
         let na_id = match chassis.network_adapters {
             Some(id) => id,
             None => {
+                let chassis_odata_url = chassis
+                    .odata
+                    .map(|o| o.odata_id)
+                    .unwrap_or_else(|| "empty_odata_id_url".to_string());
                 return Err(RedfishError::MissingKey {
                     key: "network_adapters".to_string(),
-                    url: chassis.odata.unwrap().odata_id,
-                })
+                    url: chassis_odata_url,
+                });
             }
         };
 

--- a/src/model/power.rs
+++ b/src/model/power.rs
@@ -191,9 +191,9 @@ pub struct Power {
 impl StatusVec for Power {
     fn get_vec(&self) -> Vec<ResourceStatus> {
         let mut v: Vec<ResourceStatus> = Vec::new();
-        if self.power_supplies.is_some() {
-            for res in self.power_supplies.clone().unwrap() {
-                v.push(res.status)
+        if let Some(power_supplies) = &self.power_supplies {
+            for res in power_supplies {
+                v.push(res.status);
             }
         }
         v

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -1226,8 +1226,7 @@ impl Bmc {
         let bios = self.get_bios().await?;
         let bios = bios.attributes;
 
-        if bios.acpi_spcr_console_redirection_enable.is_some() {
-            let val = bios.acpi_spcr_console_redirection_enable.unwrap();
+        if let Some(val) = bios.acpi_spcr_console_redirection_enable {
             message.push_str(&format!("acpi_spcr_console_redirection_enable={val} "));
             match val {
                 true => {
@@ -1240,8 +1239,7 @@ impl Bmc {
                 }
             }
         }
-        if bios.console_redirection_enable0.is_some() {
-            let val = bios.console_redirection_enable0.unwrap();
+        if let Some(val) = bios.console_redirection_enable0 {
             message.push_str(&format!("console_redirection_enable0={val} "));
             match val {
                 true => {
@@ -1255,30 +1253,26 @@ impl Bmc {
         // All of these need a specific value for serial console access to work.
         // Any other value counts as correctly disabled.
 
-        if bios.acpi_spcr_port.is_some() {
-            let val = bios.acpi_spcr_port.unwrap();
+        if let Some(val) = &bios.acpi_spcr_port {
             message.push_str(&format!("acpi_spcr_port={val} "));
             if val != DEFAULT_ACPI_SPCR_PORT {
                 enabled = false;
             }
         }
-        if bios.acpi_spcr_flow_control.is_some() {
-            let val = bios.acpi_spcr_flow_control.unwrap();
+        if let Some(val) = &bios.acpi_spcr_flow_control {
             message.push_str(&format!("acpi_spcr_flow_control={val} "));
             if val != DEFAULT_ACPI_SPCR_FLOW_CONTROL {
                 enabled = false;
             }
         }
-        if bios.acpi_spcr_baud_rate.is_some() {
-            let val = bios.acpi_spcr_baud_rate.unwrap();
+        if let Some(val) = &bios.acpi_spcr_baud_rate {
             message.push_str(&format!("acpi_spcr_baud_rate={val} "));
             if val != DEFAULT_ACPI_SPCR_BAUD_RATE {
                 enabled = false;
             }
         }
 
-        if bios.baud_rate0.is_some() {
-            let val = bios.baud_rate0.unwrap();
+        if let Some(val) = &bios.baud_rate0 {
             message.push_str(&format!("baud_rate0={val} "));
             if val != DEFAULT_BAUD_RATE0 {
                 enabled = false;
@@ -1318,7 +1312,7 @@ impl Bmc {
             //
             // TODO: Many BootOptions have Alias="Pxe". This probably isn't doing what we want.
             //
-            if b.alias.is_some() && b.alias.unwrap() == with_name_str {
+            if b.alias.as_deref() == Some(&with_name_str) {
                 ordered.insert(0, format!("Boot{}", b.id).to_string());
                 continue;
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -806,4 +806,3 @@ fn get_tmp_dir() -> PathBuf {
     let temp_dir = format!("{}-{}-{}", PYTHON_VENV_DIR, std::process::id(), nanos);
     env::temp_dir().join(&temp_dir)
 }
-


### PR DESCRIPTION
This replaces calls to `unwrap()` across the crate with safer alternatives.

Some patterns observed + updated include:

1. Replacing `is_some() + unwrap()` with `if let Some()`.

```
// Before:
if bios.usb_boot.is_some() {
    let val = bios.usb_boot.unwrap();
    // Do something with val.
}

// After:
if let Some(val) = bios.usb_boot {
    // Do something with val.
}
```

2. Replacing `is_some() + clone().unwrap() == "value"` with `as_deref() == Some("value")`.

```
// Before:
if bios.usb_boot.is_some() && bios.usb_boot.clone().unwrap() == "Disabled"

// After (note we can also drop the clone):
if bios.usb_boot.as_deref() == Some("Disabled")
```

3. Replacing `partial_cmp().unwrap()` with `cmp()`.

Since `Option<String>` implements `Ord`, we can use `cmp()` and not need `partial_cmp().unwrap()`.

```
// Before:
devices.sort_unstable_by(|a, b| a.manufacturer.partial_cmp(&b.manufacturer).unwrap());

// After:
devices.sort_unstable_by(|a, b| a.manufacturer.cmp(&b.manufacturer));
```

4. Improving `unwrap()` operations that are fallible.

We had a number of places where we were just unwrapping options without any error checking at all. This now returns an error with a useful error message in said cases.

```
// Before:
let system_id = systems.first().unwrap();

// After:
let system_id = systems.first().ok_or_else(|| RedfishError::GenericError {
    error: "No systems found in service root".to_string(),
})?;
```

5. Improving `unwrap()` operations that are considered infallible.

So even for operations we'd consider infallible, like setting the MIME type on an HTTP request, or having our statically compiled regex, we should still properly have an error check in there instead of blindly unwrapping.

```
// Before:
.mime_str("application/json").unwrap()

// After:
.mime_str("application/json")
.map_err(|e| RedfishError::GenericError {
    error: format!("Invalid MIME type 'application/json': {}", e),
})?
```