### PR TITLE
feat: excluded project developers DCO sign-off enforcement

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the DCO bot
+# https://github.com/probot/dco
+
+# Require all commits to be signed off EXCEPT for organization members and bots
+require:
+  members: false  # Organization members don't need to sign off


### PR DESCRIPTION
We still need to pass DCO manually until the setting merge back to default branch.

https://github.com/dcoapp/app?tab=readme-ov-file#skipping-sign-off-for-organization-members

> It is possible to disable the check for commits authored and [signed](https://help.github.com/articles/signing-commits-using-gpg/) by members of the organization the repository belongs to. To do this, place the following configuration file in .github/dco.yml on the default branch: