### PR TITLE
feat: fetch Manager's DateTime field from redfish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 version-compare = { version = "0.1" }
 regex = "1.10"
-chrono = "0.4.34"
+chrono = { version = "0.4.34", features = ["serde"] }
 urlencoding = "2.1.3"
 
 [dev-dependencies]

--- a/src/model/testdata/manager_datetime_test.json
+++ b/src/model/testdata/manager_datetime_test.json
@@ -1,0 +1,30 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+  "@odata.id": "/redfish/v1/Managers/Test.1",
+  "@odata.type": "#Manager.v1_9_0.Manager",
+  "Actions": {
+    "#Manager.Reset": {
+      "target": "/redfish/v1/Managers/Test.1/Actions/Manager.Reset"
+    }
+  },
+  "DateTime": "2025-12-05T21:07:58Z",
+  "Description": "Test Manager",
+  "EthernetInterfaces": {
+    "@odata.id": "/redfish/v1/Managers/Test.1/EthernetInterfaces"
+  },
+  "FirmwareVersion": "1.0.0",
+  "Id": "Test.1",
+  "LogServices": {
+    "@odata.id": "/redfish/v1/Managers/Test.1/LogServices"
+  },
+  "ManagerType": "BMC",
+  "Name": "Test Manager",
+  "NetworkProtocol": {
+    "@odata.id": "/redfish/v1/Managers/Test.1/NetworkProtocol"
+  },
+  "Status": {
+    "State": "Enabled"
+  },
+  "UUID": "12345678-1234-1234-1234-123456789012"
+}
+


### PR DESCRIPTION
The DateTime field contains current date and time with UTC offset of the manager, per https://redfish.dmtf.org/schemas/v1/Manager.v1_23_0.json. This field will be used during ingestion phase for time check to better deal with inconsistencies in times reported that might be caused by hardware/software issues.