### PR TITLE
fix: look through all boot options when setting boot order on GB200s 

### DIFF
--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1226,10 +1226,8 @@ impl Bmc {
         let all_boot_options: Vec<BootOption> = self
             .get_collection(boot_options_id)
             .await
-            .and_then(|c| c.try_get::<BootOption>())
-            .into_iter()
-            .flat_map(|rc| rc.members)
-            .collect();
+            .and_then(|c| c.try_get::<BootOption>())?
+            .members;
 
         // Search through all boot options to find the one we want
         let found_boot_option = all_boot_options.iter().find(|b| match match_field {


### PR DESCRIPTION
Prior to this MR, we were only looking through the existing boot order on GB200s when attempting to put the DPU first. This would cause issues when the DPU was not in it, even if it was a viable boot option. 

I've successfully verified this change on a GB200.