### PR TITLE
fix(dell): check for pending BIOS jobs before reporting setup complete

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -20,20 +20,40 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
 
-use reqwest::{header::HeaderMap, Method};
+use reqwest::header::HeaderMap;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::fs::File;
 
+use crate::model::account_service::ManagerAccount;
+use crate::model::certificate::Certificate;
+use crate::model::chassis::{Assembly, Chassis, NetworkAdapter};
+use crate::model::component_integrity::ComponentIntegrities;
+use crate::model::network_device_function::NetworkDeviceFunction;
+use crate::model::oem::dell::{self, ShareParameters, StorageCollection, SystemConfiguration};
+use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
+use crate::model::power::Power;
+use crate::model::resource::ResourceCollection;
+use crate::model::secure_boot::SecureBoot;
+use crate::model::sel::{LogEntry, LogEntryCollection};
+use crate::model::sensor::GPUSensors;
+use crate::model::service_root::{RedfishVendor, ServiceRoot};
+use crate::model::software_inventory::SoftwareInventory;
+use crate::model::storage::Drives;
+use crate::model::task::Task;
+use crate::model::thermal::Thermal;
+use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::{BootOption, ComputerSystem, InvalidValueError, Manager, OnOff};
+use crate::standard::RedfishStandard;
 use crate::{
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff, MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId, Status, StatusInternal, SystemPowerControl, jsonmap, model::{
-        BootOption, ComputerSystem, InvalidValueError, Manager, OnOff, account_service::ManagerAccount, certificate::Certificate, chassis::{Assembly, Chassis, NetworkAdapter}, component_integrity::ComponentIntegrities, network_device_function::NetworkDeviceFunction, oem::{
-            dell::{self, ShareParameters, StorageCollection, SystemConfiguration},
-            nvidia_dpu::{HostPrivilegeLevel, NicMode},
-        }, power::Power, resource::ResourceCollection, secure_boot::SecureBoot, sel::{LogEntry, LogEntryCollection}, sensor::GPUSensors, service_root::{RedfishVendor, ServiceRoot}, software_inventory::SoftwareInventory, storage::Drives, task::Task, thermal::Thermal, update_service::{ComponentType, TransferProtocolType, UpdateService}
-    }, standard::RedfishStandard
+    jsonmap, BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState,
+    MachineSetupDiff, MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError,
+    Resource, RoleId, Status, StatusInternal, SystemPowerControl,
 };
 
 const UEFI_PASSWORD_NAME: &str = "SetupPassword";
@@ -965,7 +985,8 @@ impl Redfish for Bmc {
 
     async fn is_bios_setup(&self, boot_interface_mac: Option<&str>) -> Result<bool, RedfishError> {
         let diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
-        Ok(diffs.is_empty())
+        let has_pending_jobs = self.has_pending_jobs().await?;
+        Ok(diffs.is_empty() && !has_pending_jobs)
     }
 
     async fn get_component_integrities(&self) -> Result<ComponentIntegrities, RedfishError> {
@@ -1003,7 +1024,10 @@ impl Redfish for Bmc {
         self.s.get_evidence(url).await
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 }
@@ -2059,6 +2083,83 @@ impl Bmc {
         let actual_first_boot_option = boot_order.first().map(|opt| opt.display_name.clone());
 
         Ok((expected_first_boot_option, actual_first_boot_option))
+    }
+    async fn has_pending_jobs(&self) -> Result<bool, RedfishError> {
+        // Get all jobs from the queue
+        let url = "Managers/iDRAC.Embedded.1/Oem/Dell/Jobs";
+        let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
+            self.s.client.get(url).await?;
+
+        let members = body
+            .get("Members")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| RedfishError::MissingKey {
+                key: "Members".to_string(),
+                url: url.to_string(),
+            })?;
+
+        // Check each job to see if it's BIOS-related and pending
+        for member in members {
+            let job_id = member
+                .get("@odata.id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| RedfishError::MissingKey {
+                    key: "@odata.id".to_string(),
+                    url: url.to_string(),
+                })?;
+
+            // Fetch the full job details
+            let (_status_code, job): (_, HashMap<String, serde_json::Value>) = self
+                .s
+                .client
+                .get(job_id.trim_start_matches("/redfish/v1/"))
+                .await?;
+
+            // Check if it's a BIOS job
+            let job_type = jsonmap::get_str(&job, "JobType", job_id)?;
+            if job_type != "BIOSConfiguration" {
+                continue;
+            }
+
+            // Check the job state:
+            // A special case is ScheduledWithErrors, which Dell indicates via the Message field
+            // when the JobState is Scheduled. A scheduled job with errors
+            // may never complete successfully until the errors are resolved.
+            //
+            // When a job exists to apply a configuration to  the BIOS,
+            // no other job can change the configuration until the first job is complete.
+            //
+            // You will see errors similar to:
+            //  IDRAC.2.9.SYS011 - "Pending configuration values are already committed"
+            //  See - https://www.dell.com/support/manuals/en-us/poweredge-r440/eemi_automated_2024/sys%E2%80%94system-info-event-messages?guid=guid-311c002b-8f60-4920-99fd-d293b53b0ab9&lang=en-us
+            //  SYS011
+            let job_state_value = jsonmap::get_str(&job, "JobState", job_id)?;
+            let job_state = match JobState::from_str(job_state_value) {
+                JobState::Scheduled => {
+                    // Check for ScheduledWithErrors by examining the Message field
+                    let message_value = jsonmap::get_str(&job, "Message", job_id)?;
+                    match message_value {
+                        "Job processing initialization failure." => JobState::ScheduledWithErrors,
+                        _ => JobState::Scheduled,
+                    }
+                }
+                state => state,
+            };
+
+            match job_state {
+                JobState::Scheduled | JobState::ScheduledWithErrors | JobState::Running => {
+                    tracing::info!(
+                        "Found pending BIOS job: {} in state {:?}",
+                        job_id,
+                        job_state
+                    );
+                    return Ok(true);
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(false)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,10 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-use std::{collections::HashMap, fmt, path::Path, time::Duration};
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+use std::time::Duration;
 
 pub mod model;
 use model::account_service::ManagerAccount;
@@ -29,6 +32,7 @@ pub use model::network_device_function::NetworkDeviceFunction;
 use model::oem::nvidia_dpu::{HostPrivilegeLevel, InternalCPUModel, NicMode};
 pub use model::port::NetworkPort;
 pub use model::resource::{Collection, OData, Resource};
+use model::secure_boot::SecureBoot;
 use model::sensor::GPUSensors;
 use model::service_root::{RedfishVendor, ServiceRoot};
 use model::software_inventory::SoftwareInventory;
@@ -36,8 +40,7 @@ pub use model::system::{BootOptions, PCIeDevice, PowerState, SystemPowerControl,
 use model::task::Task;
 use model::update_service::{ComponentType, TransferProtocolType, UpdateService};
 pub use model::EnabledDisabled;
-use model::Manager;
-use model::{secure_boot::SecureBoot, BootOption, ComputerSystem, ODataId};
+use model::{BootOption, ComputerSystem, Manager, ODataId};
 use serde::{Deserialize, Serialize};
 mod dell;
 mod error;
@@ -544,9 +547,9 @@ pub trait Redfish: Send + Sync + 'static {
         url: &str,
     ) -> Result<model::component_integrity::Evidence, RedfishError>;
 
-     // Sets the host privilege level for a DPU
-     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError>;
-
+    // Sets the host privilege level for a DPU
+    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel)
+        -> Result<(), RedfishError>;
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -37,15 +37,11 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
-use libredfish::model::{certificate::Certificate, service_root::RedfishVendor};
-use libredfish::model::{ComputerSystem, ODataId};
-use libredfish::{
-    model::{
-        resource::{IsResource, ResourceCollection},
-        Manager,
-    },
-    Chassis, EthernetInterface, NetworkAdapter, PCIeDevice, Redfish,
-};
+use libredfish::model::certificate::Certificate;
+use libredfish::model::resource::{IsResource, ResourceCollection};
+use libredfish::model::service_root::RedfishVendor;
+use libredfish::model::{ComputerSystem, Manager, ODataId};
+use libredfish::{Chassis, EthernetInterface, NetworkAdapter, PCIeDevice, Redfish};
 use tracing::debug;
 
 const ROOT_DIR: &str = env!("CARGO_MANIFEST_DIR");
@@ -237,9 +233,10 @@ async fn nvidia_dpu_integration_test(redfish: &dyn Redfish) -> Result<(), anyhow
 
 fn run_mockup_server(vendor_dir: &'static str, port: &'static str) -> anyhow::Result<MockupServer> {
     SETUP.call_once(move || {
+        use tracing_subscriber::filter::LevelFilter;
         use tracing_subscriber::fmt::Layer;
         use tracing_subscriber::prelude::*;
-        use tracing_subscriber::{filter::LevelFilter, EnvFilter};
+        use tracing_subscriber::EnvFilter;
         tracing_subscriber::registry()
             .with(
                 EnvFilter::builder()
@@ -499,6 +496,16 @@ async fn run_integration_test(
     if vendor_dir == "dell" {
         let firmware = redfish.get_firmware_for_component("ERoT_BMC_0").await;
         assert!(firmware.is_err());
+
+        // Test is_bios_setup which internally calls has_pending_jobs()
+        // The dell mockup has one completed BIOS job (JID_102241909559)
+        // so has_pending_jobs should return false (no pending jobs)
+        // This test verifies the function doesn't panic and correctly handles completed jobs
+        let is_setup = redfish.is_bios_setup(None).await?;
+        debug!(
+            "is_bios_setup returned: {} (Dell mockup has completed BIOS job, no pending)",
+            is_setup
+        );
     }
 
     test_vendor_collection_count!(


### PR DESCRIPTION
  Dell iDRAC has a race condition where the /Bios endpoint returns
  pending values before the BIOS configuration job completes.  This
  causes is_bios_setup() to incorrectly return True when:

  1. BIOS settings are PATCHed to /Bios/Settings, creating a scheduled job
  2. System reboot to apply settings
  3. Dell updates /Bios with pending values BEFORE the job completes
  4. diff_bios_bmc_attr() compares expected values vs actual values, both come from the same /Bios endpoint containing pending values
     - dell.rs:1047 actual values from bios_attributes() -> GET /Bios
     - dell.rs:1053 expected values from machine_setup_attrs() -> dell.rs:1706 -> bios_attributes() -> GET /Bios (same endpoint)
  5. Diff returns emtpy (false positive) -> is_bios_setup() returns true
  6. A client attempts to set boot order while the BIOSConfiguration job is still running
  7. iDRAC rejects the attempted change with error "Pending configuration values are already commited"

  The fix adds has_pending_jobs() which queries the Dell job queue and
  checks for any BIOSConfiguration jobs in Scheduled,
  ScheduledWithErrors, or Running states.  Now is_bios_setup() returns
  true only when BOTH:
  - Attributes diffs are empty
  - No Pending BIOS jobs exists

  This prevents premature operations on the BMC.