### PR TITLE
fix: update datetime parsing to handle timezone offsets correctly

### DIFF
--- a/src/model/manager.rs
+++ b/src/model/manager.rs
@@ -164,22 +164,25 @@ mod test {
 
     #[test]
     fn test_manager_datetime_parsing() {
-        // Test parsing RFC3339 datetime format
+        // Test parsing RFC3339 datetime format with timezone offset
+        // The input has -06:00 offset, which gets converted to UTC
         let json_data = include_str!("testdata/manager_datetime_test.json");
 
         let manager: super::Manager = serde_json::from_str(json_data).unwrap();
         assert!(manager.date_time.is_some());
         
         let dt = manager.date_time.unwrap();
+        // Input: 2025-12-05T21:07:58-06:00
+        // UTC:   2025-12-06T03:07:58+00:00 (21:07 + 6 hours = 03:07 next day)
         assert_eq!(dt.year(), 2025);
         assert_eq!(dt.month(), 12);
-        assert_eq!(dt.day(), 5);
-        assert_eq!(dt.hour(), 21);
+        assert_eq!(dt.day(), 6); // Next day in UTC
+        assert_eq!(dt.hour(), 3); // 21 + 6 = 27 -> 3 (next day)
         assert_eq!(dt.minute(), 7);
         assert_eq!(dt.second(), 58);
         
-        // Verify the datetime string format
+        // Verify the datetime is converted to UTC format
         let dt_str = dt.to_rfc3339();
-        assert_eq!(dt_str, "2025-12-05T21:07:58+00:00");
+        assert_eq!(dt_str, "2025-12-06T03:07:58+00:00");
     }
 }

--- a/src/model/testdata/manager_datetime_test.json
+++ b/src/model/testdata/manager_datetime_test.json
@@ -7,7 +7,7 @@
       "target": "/redfish/v1/Managers/Test.1/Actions/Manager.Reset"
     }
   },
-  "DateTime": "2025-12-05T21:07:58Z",
+  "DateTime": "2025-12-05T21:07:58-06:00",
   "Description": "Test Manager",
   "EthernetInterfaces": {
     "@odata.id": "/redfish/v1/Managers/Test.1/EthernetInterfaces"
@@ -27,4 +27,3 @@
   },
   "UUID": "12345678-1234-1234-1234-123456789012"
 }
-


### PR DESCRIPTION
Modified the datetime parsing test to account for timezone offsets in the input data. The test now verifies that the datetime is correctly converted to UTC, reflecting the change from a -06:00 offset to UTC. Updated the test data to include the timezone offset in the JSON file.