### PR TITLE
chore: implement `set_utc_timezone` API to use UTC timezone

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1006,6 +1006,19 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        let manager_id = self.s.manager_id();
+        let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
+
+        let mut timezone_attrs = HashMap::new();
+        timezone_attrs.insert("Time.1.Timezone", "UTC");
+
+        let body = HashMap::from([("Attributes", timezone_attrs)]);
+
+        self.s.client.patch(&url, body).await?;
+        Ok(())
+    }
 }
 
 impl Bmc {

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -916,6 +916,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -1038,6 +1038,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,6 +547,10 @@ pub trait Redfish: Send + Sync + 'static {
      // Sets the host privilege level for a DPU
      async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError>;
 
+     // Sets the timezone to UTC
+     // Only applicable to Dells
+     async fn set_utc_timezone(&self) -> Result<(), RedfishError>;
+
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -732,6 +732,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/model/manager.rs
+++ b/src/model/manager.rs
@@ -164,22 +164,25 @@ mod test {
 
     #[test]
     fn test_manager_datetime_parsing() {
-        // Test parsing RFC3339 datetime format
+        // Test parsing RFC3339 datetime format with timezone offset
+        // The input has -06:00 offset, which gets converted to UTC
         let json_data = include_str!("testdata/manager_datetime_test.json");
 
         let manager: super::Manager = serde_json::from_str(json_data).unwrap();
         assert!(manager.date_time.is_some());
         
         let dt = manager.date_time.unwrap();
+        // Input: 2025-12-05T21:07:58-06:00
+        // UTC:   2025-12-06T03:07:58+00:00 (21:07 + 6 hours = 03:07 next day)
         assert_eq!(dt.year(), 2025);
         assert_eq!(dt.month(), 12);
-        assert_eq!(dt.day(), 5);
-        assert_eq!(dt.hour(), 21);
+        assert_eq!(dt.day(), 6); // Next day in UTC
+        assert_eq!(dt.hour(), 3); // 21 + 6 = 27 -> 3 (next day)
         assert_eq!(dt.minute(), 7);
         assert_eq!(dt.second(), 58);
         
-        // Verify the datetime string format
+        // Verify the datetime is converted to UTC format
         let dt_str = dt.to_rfc3339();
-        assert_eq!(dt_str, "2025-12-05T21:07:58+00:00");
+        assert_eq!(dt_str, "2025-12-06T03:07:58+00:00");
     }
 }

--- a/src/model/testdata/manager_datetime_test.json
+++ b/src/model/testdata/manager_datetime_test.json
@@ -7,7 +7,7 @@
       "target": "/redfish/v1/Managers/Test.1/Actions/Manager.Reset"
     }
   },
-  "DateTime": "2025-12-05T21:07:58Z",
+  "DateTime": "2025-12-05T21:07:58-06:00",
   "Description": "Test Manager",
   "EthernetInterfaces": {
     "@odata.id": "/redfish/v1/Managers/Test.1/EthernetInterfaces"
@@ -27,4 +27,3 @@
   },
   "UUID": "12345678-1234-1234-1234-123456789012"
 }
-

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -885,6 +885,10 @@ impl Redfish for Bmc {
             .await
             .map(|_status_code| Ok(()))?
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -824,6 +824,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1099,6 +1099,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -784,6 +784,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -982,6 +982,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -926,6 +926,11 @@ impl Redfish for RedfishStandard {
     async fn set_host_privilege_level(&self, _level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         Err(RedfishError::NotSupported("set_host_privilege_level".to_string()))
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        // No-op for non-Dell vendors
+        Ok(())
+    }
 }
 
 impl RedfishStandard {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -910,6 +910,10 @@ impl Redfish for Bmc {
     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
+
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        self.s.set_utc_timezone().await
+    }
 }
 
 impl Bmc {


### PR DESCRIPTION
For non-dell servers, this operation is currently a no-op.