### PR TITLE
fix: don't capture parent tracing span in http requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@ pub use network::{Endpoint, RedfishClientPool, RedfishClientPoolBuilder, REDFISH
 pub mod standard;
 pub use error::RedfishError;
 
+/// Reexported of reqwest for types needed in
+/// RedfishClientPoolBuilder.
+pub use reqwest;
+
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
 use crate::model::power::Power;


### PR DESCRIPTION
This fixes issue of capturing parent tracing span by long-living HTTP threads in hyper. 

Here are details:

hyper-util's TokioExecutor spawns background tasks using .in_current_span() when the tracing feature is enabled.
tracing feature is not enabled by libredfish directly or through reqwest but may be enabled by feature unification that comes with another dependencies. 
