### PR TITLE
fix: change path to set boot order on dells

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -850,7 +850,7 @@ impl Redfish for Bmc {
                     return Ok(None);
                 }
 
-                let url = format!("Systems/{}", self.s.system_id());
+                let url = format!("Systems/{}/Settings", self.s.system_id());
                 let body = HashMap::from([(
                     "Boot",
                     HashMap::from([("BootOrder", vec![boot_option.id.clone()])]),


### PR DESCRIPTION
This PR changes the redfish path to change the boot order on Dells from `redfish/v1/Systems/System.Embedded.1` to `redfish/v1/Systems/System.Embedded.1/Settings`. 

The previous path would fail on iDRAC10 with the following error. I've manually verified that this change works on both iDRAC9 and iDRAC10. 

```
Error: 
HTTP 400 Bad Request at https://<bmc-ip>/redfish/v1/Systems/System.Embedded.1: {"error":
{"@Message.ExtendedInfo":[{"Message":"The property Boot is a read-only property and cannot be assigned a value.","MessageArgs":
["Boot"],"MessageArgs@odata.count":1,"MessageId":"Base.1.18.PropertyNotWritable","RelatedProperties":
["#/Boot"],"RelatedProperties@odata.count":1,"Resolution":"Remove the property from the request body and resubmit the
request if the operation failed.","Severity":"Warning"}],"code":"Base.1.18.GeneralError","message":"A general error has 
occurred. See ExtendedInfo for more information"}}
```