### PR TITLE
fix: dynamically assign raid type when creating a storage volume for Dells

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -825,10 +825,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -881,10 +881,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -935,10 +935,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,6 @@ pub trait Redfish: Send + Sync + 'static {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError>;
 
     fn ac_powercycle_supported_by_power(&self) -> bool;

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -632,10 +632,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -798,10 +798,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -724,10 +724,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1017,10 +1017,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -684,10 +684,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -948,10 +948,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -873,7 +873,6 @@ impl Redfish for RedfishStandard {
         &self,
         _controller_id: &str,
         _volume_name: &str,
-        _raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         Err(RedfishError::NotSupported(
             "create_storage_volume".to_string(),

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -874,10 +874,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 


### PR DESCRIPTION
This PR dynamically finds the RAID type based on the amount of drives present in the BOSS controller instead of taking it as input in `create_storage_volume()`.

- 1 drive = `RAID0`
- 2 drives = `RAID1`
- else, throw an error