### PR TITLE
fix: new endpoint to fetch lifecycle controller status for dells

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -2176,9 +2176,9 @@ impl Bmc {
     }
 
     async fn get_lifecycle_controller_status(&self) -> Result<String, RedfishError> {
+        let manager_id = self.s.manager_id();
         let url = format!(
-            "Dell/Managers/{}/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus",
-            self.s.manager_id()
+            "Managers/{manager_id}/Oem/Dell/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus"
         );
         let arg: HashMap<&'static str, Value> = HashMap::new();
         let (_status_code, resp_body, _resp_headers): (


### PR DESCRIPTION
This PR updates the endpoint to fetch the lifecycle controller status for Dells.

Old: `redfish/v1/Dell/Managers/{}/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus`
New: `redfish/v1/Managers/{}/Oem/Dell/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus`

This change has been manually verified on multiple Dell machines running different iDRAC versions.