### PR TITLE
fix: [Dell] new volume creation payload + deserialize chassis power_state properly

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -2163,11 +2163,11 @@ impl Bmc {
         self.lifecycle_controller_is_ready().await?;
 
         let url: String = format!("Systems/System.Embedded.1/Storage/{controller_id}/Volumes");
-        let mut arg = HashMap::new();
-
-        arg.insert("Name", Value::String(volume_name.to_string()));
-        arg.insert("RAIDType", Value::String(raid_type.to_string()));
-        arg.insert("Drives", drive_info);
+        let arg = HashMap::from([
+            ("Name", Value::String(volume_name.to_string())),
+            ("RAIDType", Value::String(raid_type.to_string())),
+            ("Links", serde_json::json!({ "Drives": drive_info })),
+        ]);
 
         match self.s.client.post(&url, arg).await? {
             (_, Some(headers)) => self.parse_job_id_from_response_headers(&url, headers).await,

--- a/src/model/chassis.rs
+++ b/src/model/chassis.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use super::oem::ChassisExtensions;
 use super::resource::OData;
-use super::{ODataId, ODataLinks, OnOff, PCIeFunction, ResourceStatus};
+use super::{ODataId, ODataLinks, PCIeFunction, PowerState, ResourceStatus};
 use crate::NetworkDeviceFunction;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -117,7 +117,7 @@ pub struct Chassis {
     pub part_number: Option<String>,
     pub power: Option<ODataId>,
     #[serde(default)] // Viking returns Chassis w.o power_state, so default will be used
-    pub power_state: Option<OnOff>,
+    pub power_state: Option<PowerState>,
     pub power_subsystem: Option<ODataId>,
     pub sensors: Option<ODataId>,
     pub serial_number: Option<String>,


### PR DESCRIPTION
In `create_storage_volume`, nest drives under `Links/Drives` instead of top-level `Drives` to match how Dell expects the payload ([source](https://github.com/dell/iDRAC-Redfish-Scripting/blob/d92010338642e7320d41575d0f4e3af371ce4ead/Redfish%20Python/CreateVirtualDiskREDFISH.py#L276)).

Change `Chassis.power_state` type from `OnOff` to `PowerState`, allowing transitional states like `PoweringOn` and `PoweringOff` to deserialize correctly instead of failing.
- This fixes an issue where iDRAC10 returns an unknown variant `PoweringOn` when only `On`, `Off`, or `Reset` were accepted.

