### PR TITLE
Configure Dell BIOS task IDs in machine setup

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -293,6 +293,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
@@ -942,9 +946,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -293,12 +293,12 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
         let attrs = self.machine_setup_attrs();
         self.set_bios(attrs).await?;
-        Ok(())
+        Ok(None)
     }
 
     /// Check machine setup status for AMI BMC.

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -261,9 +261,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> machine_setup");
+    ) -> Result<Option<String>, RedfishError> {
+        println!("<kcdTaskIDs> machine_setup entry");
         self.delete_job_queue().await?;
+        println!("<kcdTaskIDs> machine_setup job queue deleted");
 
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
@@ -271,14 +272,19 @@ impl Redfish for Bmc {
 
         let (nic_slot, has_dpu) = match boot_interface_mac {
             Some(mac) => {
+                println!("<kcdTaskIDs> machine_setup resolving nic_slot for mac {}", mac);
                 let slot: String = self.dpu_nic_slot(mac).await?;
                 (slot, true)
             }
             // Zero-DPU case
-            None => ("".to_string(), false),
+            None => {
+                println!("<kcdTaskIDs> machine_setup zero-DPU case");
+                ("".to_string(), false)
+            }
         };
 
         // dell idrac requires applying all bios settings at once.
+        println!("<kcdTaskIDs> machine_setup fetching machine_setup_attrs");
         let machine_settings = self.machine_setup_attrs(&nic_slot).await?;
         let set_machine_attrs = dell::SetBiosAttrs {
             redfish_settings_apply_time: apply_time,
@@ -310,19 +316,32 @@ impl Redfish for Bmc {
         }
 
         let url = format!("Systems/{}/Bios/Settings/", self.s.system_id());
-        match self.s.client.patch(&url, set_machine_attrs).await? {
-            (_, Some(headers)) => self.parse_job_id_from_response_headers(&url, headers).await,
-            (_, None) => Err(RedfishError::NoHeader),
-        }?;
+        println!("<kcdTaskIDs> machine_setup PATCHing BIOS Settings url={}", url);
+        let bios_job_id = match self.s.client.patch(&url, set_machine_attrs).await? {
+            (_, Some(headers)) => {
+                let jid = self.parse_job_id_from_response_headers(&url, headers).await?;
+                println!("<kcdTaskIDs> machine_setup BIOS PATCH returned task/job id={}", jid);
+                Some(jid)
+            }
+            (_, None) => {
+                println!("<kcdTaskIDs> machine_setup BIOS PATCH returned no Location header");
+                return Err(RedfishError::NoHeader);
+            }
+        };
 
+        println!("<kcdTaskIDs> machine_setup running machine_setup_oem");
         self.machine_setup_oem().await?;
+        println!("<kcdTaskIDs> machine_setup running setup_bmc_remote_access");
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
-            Ok(())
+            println!(
+                "<kcdTaskIDs> machine_setup success, returning bios_job_id={:?}",
+                bios_job_id
+            );
+            Ok(bios_job_id)
         } else {
-            // Usually a missing DPU is an error, but for zero-dpu it isn't
-            // Tell the caller and let them decide
+            println!("<kcdTaskIDs> machine_setup NoDpu (zero-DPU)");
             Err(RedfishError::NoDpu)
         }
     }
@@ -877,7 +896,7 @@ impl Redfish for Bmc {
     }
 
     async fn get_job_state(&self, job_id: &str) -> Result<JobState, RedfishError> {
-        println!("<kcdPrint> get_job_state");
+        println!("<kcdTaskIDs> get_job_state job_id={}", job_id);
         let url = format!("Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{}", job_id);
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
@@ -917,6 +936,10 @@ impl Redfish for Bmc {
             state => state,
         };
 
+        println!(
+            "<kcdTaskIDs> get_job_state job_id={} returning state={:?}",
+            job_id, job_state
+        );
         Ok(job_state)
     }
 
@@ -2056,9 +2079,9 @@ impl Bmc {
         url: &str,
         resp_headers: HeaderMap,
     ) -> Result<String, RedfishError> {
-        println!("<kcdPrint> parse_job_id_from_response_headers");
+        println!("<kcdTaskIDs> parse_job_id_from_response_headers url={}", url);
         let key = "location";
-        Ok(resp_headers
+        let jid = resp_headers
             .get(key)
             .ok_or_else(|| RedfishError::MissingKey {
                 key: key.to_string(),
@@ -2077,7 +2100,9 @@ impl Bmc {
                 field: key.to_string(),
                 err: InvalidValueError("unable to parse job_id from location string".to_string()),
             })?
-            .to_string())
+            .to_string();
+        println!("<kcdTaskIDs> parse_job_id_from_response_headers parsed job_id={}", jid);
+        Ok(jid)
     }
 
     /// import_system_configuration returns the job ID for importing this sytem configuration

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -287,23 +287,14 @@ impl Redfish for Bmc {
         }
 
         let url = format!("Systems/{}/Bios/Settings/", self.s.system_id());
-        println!(
-            "<kcdLibredfishTaskID> machine_setup PATCH BIOS Settings url={url} (expect Dell BIOS config job id from Location header)"
-        );
         let bios_job_id = match self.s.client.patch(&url, set_machine_attrs).await? {
             (_, Some(headers)) => {
                 let jid = self
                     .parse_job_id_from_response_headers(&url, headers)
                     .await?;
-                println!(
-                    "<kcdLibredfishTaskID> machine_setup got BIOS config job_id={jid} from PATCH response"
-                );
                 Some(jid)
             }
             (_, None) => {
-                println!(
-                    "<kcdLibredfishTaskID> machine_setup PATCH returned no Location header (NoHeader)"
-                );
                 return Err(RedfishError::NoHeader);
             }
         };
@@ -312,15 +303,8 @@ impl Redfish for Bmc {
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
-            println!(
-                "<kcdLibredfishTaskID> machine_setup returning Ok(job_id={bios_job_id:?}) for DPU host"
-            );
             Ok(bios_job_id)
         } else {
-            println!(
-                "<kcdLibredfishTaskID> machine_setup zero-DPU path returning Err(NoDpu) (caller may treat as Ok)"
-            );
-            // Usually a missing DPU is an error, but for zero-dpu it isn't
             // Tell the caller and let them decide
             Err(RedfishError::NoDpu)
         }
@@ -828,9 +812,6 @@ impl Redfish for Bmc {
 
     async fn get_job_state(&self, job_id: &str) -> Result<JobState, RedfishError> {
         let url = format!("Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{}", job_id);
-        println!(
-            "<kcdLibredfishTaskID> get_job_state job_id={job_id} GET {url}"
-        );
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
         let job_state_value = jsonmap::get_str(&body, "JobState", &url)?;
@@ -869,9 +850,6 @@ impl Redfish for Bmc {
             state => state,
         };
 
-        println!(
-            "<kcdLibredfishTaskID> get_job_state job_id={job_id} -> JobState={job_state:?}"
-        );
         Ok(job_state)
     }
 
@@ -911,16 +889,10 @@ impl Redfish for Bmc {
 
                 let job_id = match self.s.client.patch(&url, body).await? {
                     (_, Some(headers)) => {
-                        println!(
-                            "<kcdLibredfishTaskID> set_boot_order_dpu_first PATCH {url} (boot order job)"
-                        );
                         self.parse_job_id_from_response_headers(&url, headers).await
                     }
                     (_, None) => Err(RedfishError::NoHeader),
                 }?;
-                println!(
-                    "<kcdLibredfishTaskID> set_boot_order_dpu_first job_id={job_id}"
-                );
                 return Ok(Some(job_id));
             }
         }
@@ -1984,9 +1956,6 @@ impl Bmc {
                 err: InvalidValueError("unable to parse job_id from location string".to_string()),
             })?
             .to_string();
-        println!(
-            "<kcdLibredfishTaskID> parse_job_id_from_response_headers url={url} -> job_id={jid}"
-        );
         Ok(jid)
     }
 

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -287,14 +287,23 @@ impl Redfish for Bmc {
         }
 
         let url = format!("Systems/{}/Bios/Settings/", self.s.system_id());
+        println!(
+            "<kcdLibredfishTaskID> machine_setup PATCH BIOS Settings url={url} (expect Dell BIOS config job id from Location header)"
+        );
         let bios_job_id = match self.s.client.patch(&url, set_machine_attrs).await? {
             (_, Some(headers)) => {
                 let jid = self
                     .parse_job_id_from_response_headers(&url, headers)
                     .await?;
+                println!(
+                    "<kcdLibredfishTaskID> machine_setup got BIOS config job_id={jid} from PATCH response"
+                );
                 Some(jid)
             }
             (_, None) => {
+                println!(
+                    "<kcdLibredfishTaskID> machine_setup PATCH returned no Location header (NoHeader)"
+                );
                 return Err(RedfishError::NoHeader);
             }
         };
@@ -303,8 +312,14 @@ impl Redfish for Bmc {
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
+            println!(
+                "<kcdLibredfishTaskID> machine_setup returning Ok(job_id={bios_job_id:?}) for DPU host"
+            );
             Ok(bios_job_id)
         } else {
+            println!(
+                "<kcdLibredfishTaskID> machine_setup zero-DPU path returning Err(NoDpu) (caller may treat as Ok)"
+            );
             // Usually a missing DPU is an error, but for zero-dpu it isn't
             // Tell the caller and let them decide
             Err(RedfishError::NoDpu)
@@ -813,6 +828,9 @@ impl Redfish for Bmc {
 
     async fn get_job_state(&self, job_id: &str) -> Result<JobState, RedfishError> {
         let url = format!("Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{}", job_id);
+        println!(
+            "<kcdLibredfishTaskID> get_job_state job_id={job_id} GET {url}"
+        );
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
         let job_state_value = jsonmap::get_str(&body, "JobState", &url)?;
@@ -851,6 +869,9 @@ impl Redfish for Bmc {
             state => state,
         };
 
+        println!(
+            "<kcdLibredfishTaskID> get_job_state job_id={job_id} -> JobState={job_state:?}"
+        );
         Ok(job_state)
     }
 
@@ -890,10 +911,16 @@ impl Redfish for Bmc {
 
                 let job_id = match self.s.client.patch(&url, body).await? {
                     (_, Some(headers)) => {
+                        println!(
+                            "<kcdLibredfishTaskID> set_boot_order_dpu_first PATCH {url} (boot order job)"
+                        );
                         self.parse_job_id_from_response_headers(&url, headers).await
                     }
                     (_, None) => Err(RedfishError::NoHeader),
                 }?;
+                println!(
+                    "<kcdLibredfishTaskID> set_boot_order_dpu_first job_id={job_id}"
+                );
                 return Ok(Some(job_id));
             }
         }
@@ -1957,6 +1984,9 @@ impl Bmc {
                 err: InvalidValueError("unable to parse job_id from location string".to_string()),
             })?
             .to_string();
+        println!(
+            "<kcdLibredfishTaskID> parse_job_id_from_response_headers url={url} -> job_id={jid}"
+        );
         Ok(jid)
     }
 

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -74,6 +74,7 @@ impl Redfish for Bmc {
         password: &str,
         role_id: RoleId,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> create_user");
         // Find an unused ID
         // 'root' is typically ID 2 on an iDrac, and ID 1 might be special
         let mut account_id = 3;
@@ -103,14 +104,17 @@ impl Redfish for Bmc {
     }
 
     async fn delete_user(&self, username: &str) -> Result<(), RedfishError> {
+        println!("<kcdPrint> delete_user");
         self.s.delete_user(username).await
     }
 
     async fn change_username(&self, old_name: &str, new_name: &str) -> Result<(), RedfishError> {
+        println!("<kcdPrint> change_username");
         self.s.change_username(old_name, new_name).await
     }
 
     async fn change_password(&self, username: &str, new_pass: &str) -> Result<(), RedfishError> {
+        println!("<kcdPrint> change_password");
         self.s.change_password(username, new_pass).await
     }
 
@@ -119,22 +123,27 @@ impl Redfish for Bmc {
         account_id: &str,
         new_pass: &str,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> change_password_by_id");
         self.s.change_password_by_id(account_id, new_pass).await
     }
 
     async fn get_accounts(&self) -> Result<Vec<ManagerAccount>, RedfishError> {
+        println!("<kcdPrint> get_accounts");
         self.s.get_accounts().await
     }
 
     async fn get_power_state(&self) -> Result<PowerState, RedfishError> {
+        println!("<kcdPrint> get_power_state");
         self.s.get_power_state().await
     }
 
     async fn get_power_metrics(&self) -> Result<Power, RedfishError> {
+        println!("<kcdPrint> get_power_metrics");
         self.s.get_power_metrics().await
     }
 
     async fn power(&self, action: SystemPowerControl) -> Result<(), RedfishError> {
+        println!("<kcdPrint> power");
         if action == SystemPowerControl::ACPowercycle {
             let is_lockdown = self.is_lockdown().await?;
             let bios_attrs = self.s.bios_attributes().await?;
@@ -155,10 +164,12 @@ impl Redfish for Bmc {
     }
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
+        println!("<kcdPrint> ac_powercycle_supported_by_power");
         true
     }
 
     async fn bmc_reset(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> bmc_reset");
         self.s.bmc_reset().await
     }
 
@@ -167,22 +178,27 @@ impl Redfish for Bmc {
         chassis_id: &str,
         reset_type: SystemPowerControl,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> chassis_reset");
         self.s.chassis_reset(chassis_id, reset_type).await
     }
 
     async fn get_thermal_metrics(&self) -> Result<Thermal, RedfishError> {
+        println!("<kcdPrint> get_thermal_metrics");
         self.s.get_thermal_metrics().await
     }
 
     async fn get_gpu_sensors(&self) -> Result<Vec<GPUSensors>, RedfishError> {
+        println!("<kcdPrint> get_gpu_sensors");
         self.s.get_gpu_sensors().await
     }
 
     async fn get_update_service(&self) -> Result<UpdateService, RedfishError> {
+        println!("<kcdPrint> get_update_service");
         self.s.get_update_service().await
     }
 
     async fn get_system_event_log(&self) -> Result<Vec<LogEntry>, RedfishError> {
+        println!("<kcdPrint> get_system_event_log");
         self.get_system_event_log().await
     }
 
@@ -190,15 +206,18 @@ impl Redfish for Bmc {
         &self,
         from: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<Vec<LogEntry>, RedfishError> {
+        println!("<kcdPrint> get_bmc_event_log");
         // Different Dell timestamp formats (UTC-5, DST, etc..) are making filtering and comparing very difficult
         self.s.get_bmc_event_log(from).await
     }
 
     async fn get_drives_metrics(&self) -> Result<Vec<Drives>, RedfishError> {
+        println!("<kcdPrint> get_drives_metrics");
         self.s.get_drives_metrics().await
     }
 
     async fn bios(&self) -> Result<HashMap<String, serde_json::Value>, RedfishError> {
+        println!("<kcdPrint> bios");
         self.s.bios().await
     }
 
@@ -206,6 +225,7 @@ impl Redfish for Bmc {
         &self,
         values: HashMap<String, serde_json::Value>,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_bios");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -224,10 +244,12 @@ impl Redfish for Bmc {
     }
 
     async fn reset_bios(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> reset_bios");
         self.s.factory_reset_bios().await
     }
 
     async fn get_base_mac_address(&self) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> get_base_mac_address");
         self.s.get_base_mac_address().await
     }
 
@@ -240,6 +262,7 @@ impl Redfish for Bmc {
         >,
         selected_profile: BiosProfileType,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> machine_setup");
         self.delete_job_queue().await?;
 
         let apply_time = dell::SetSettingsApplyTime {
@@ -308,6 +331,7 @@ impl Redfish for Bmc {
         &self,
         boot_interface_mac: Option<&str>,
     ) -> Result<MachineSetupStatus, RedfishError> {
+        println!("<kcdPrint> machine_setup_status");
         // Check BIOS and BMC attributes
         let mut diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
 
@@ -342,6 +366,7 @@ impl Redfish for Bmc {
     /// iDRAC does not suport changing password policy. They support IP blocking instead.
     /// https://github.com/dell/iDRAC-Redfish-Scripting/issues/295
     async fn set_machine_password_policy(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_machine_password_policy");
         // These are all password policy a Dell has, and they are all read only.
         // Redfish will reject attempts to modify them.
         // - AccountLockoutThreshold
@@ -352,6 +377,7 @@ impl Redfish for Bmc {
     }
 
     async fn lockdown(&self, target: EnabledDisabled) -> Result<(), RedfishError> {
+        println!("<kcdPrint> lockdown");
         use EnabledDisabled::*;
         // XE9680's can't PXE boot for some reason
         let system = self.s.get_system().await?;
@@ -373,6 +399,7 @@ impl Redfish for Bmc {
     }
 
     async fn lockdown_status(&self) -> Result<Status, RedfishError> {
+        println!("<kcdPrint> lockdown_status");
         let mut message = String::new();
         let enabled = EnabledDisabled::Enabled.to_string();
         let disabled = EnabledDisabled::Disabled.to_string();
@@ -402,6 +429,7 @@ impl Redfish for Bmc {
     }
 
     async fn setup_serial_console(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> setup_serial_console");
         self.delete_job_queue().await?;
 
         self.setup_bmc_remote_access().await?;
@@ -460,6 +488,7 @@ impl Redfish for Bmc {
     }
 
     async fn serial_console_status(&self) -> Result<Status, RedfishError> {
+        println!("<kcdPrint> serial_console_status");
         let Status {
             status: remote_access_status,
             message: remote_access_message,
@@ -484,14 +513,17 @@ impl Redfish for Bmc {
     }
 
     async fn get_boot_options(&self) -> Result<BootOptions, RedfishError> {
+        println!("<kcdPrint> get_boot_options");
         self.s.get_boot_options().await
     }
 
     async fn get_boot_option(&self, option_id: &str) -> Result<BootOption, RedfishError> {
+        println!("<kcdPrint> get_boot_option");
         self.s.get_boot_option(option_id).await
     }
 
     async fn boot_once(&self, target: Boot) -> Result<(), RedfishError> {
+        println!("<kcdPrint> boot_once");
         match target {
             Boot::Pxe => self.set_boot_first(dell::BootDevices::PXE, true).await,
             Boot::HardDisk => self.set_boot_first(dell::BootDevices::HDD, true).await,
@@ -502,6 +534,7 @@ impl Redfish for Bmc {
     }
 
     async fn boot_first(&self, target: Boot) -> Result<(), RedfishError> {
+        println!("<kcdPrint> boot_first");
         match target {
             Boot::Pxe => self.set_boot_first(dell::BootDevices::PXE, false).await,
             Boot::HardDisk => self.set_boot_first(dell::BootDevices::HDD, false).await,
@@ -512,6 +545,7 @@ impl Redfish for Bmc {
     }
 
     async fn clear_tpm(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> clear_tpm");
         self.delete_job_queue().await?;
 
         let apply_time = dell::SetSettingsApplyTime {
@@ -534,14 +568,17 @@ impl Redfish for Bmc {
     }
 
     async fn pending(&self) -> Result<HashMap<String, serde_json::Value>, RedfishError> {
+        println!("<kcdPrint> pending");
         self.s.pending().await
     }
 
     async fn clear_pending(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> clear_pending");
         self.delete_job_queue().await
     }
 
     async fn pcie_devices(&self) -> Result<Vec<PCIeDevice>, RedfishError> {
+        println!("<kcdPrint> pcie_devices");
         self.s.pcie_devices().await
     }
 
@@ -549,6 +586,7 @@ impl Redfish for Bmc {
         &self,
         firmware: tokio::fs::File,
     ) -> Result<crate::model::task::Task, RedfishError> {
+        println!("<kcdPrint> update_firmware");
         self.s.update_firmware(firmware).await
     }
 
@@ -560,6 +598,7 @@ impl Redfish for Bmc {
         timeout: Duration,
         _component_type: ComponentType,
     ) -> Result<String, RedfishError> {
+        println!("<kcdPrint> update_firmware_multipart");
         let firmware = File::open(&filename)
             .await
             .map_err(|e| RedfishError::FileError(format!("Could not open file: {e}")))?;
@@ -595,22 +634,27 @@ impl Redfish for Bmc {
     }
 
     async fn get_tasks(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_tasks");
         self.s.get_tasks().await
     }
 
     async fn get_task(&self, id: &str) -> Result<crate::model::task::Task, RedfishError> {
+        println!("<kcdPrint> get_task");
         self.s.get_task(id).await
     }
 
     async fn get_firmware(&self, id: &str) -> Result<SoftwareInventory, RedfishError> {
+        println!("<kcdPrint> get_firmware");
         self.s.get_firmware(id).await
     }
 
     async fn get_software_inventories(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_software_inventories");
         self.s.get_software_inventories().await
     }
 
     async fn get_system(&self) -> Result<ComputerSystem, RedfishError> {
+        println!("<kcdPrint> get_system");
         self.s.get_system().await
     }
 
@@ -619,6 +663,7 @@ impl Redfish for Bmc {
         database_id: &str,
         certificate_id: &str,
     ) -> Result<Certificate, RedfishError> {
+        println!("<kcdPrint> get_secure_boot_certificate");
         self.s
             .get_secure_boot_certificate(database_id, certificate_id)
             .await
@@ -628,6 +673,7 @@ impl Redfish for Bmc {
         &self,
         database_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_secure_boot_certificates");
         self.s.get_secure_boot_certificates(database_id).await
     }
 
@@ -636,20 +682,24 @@ impl Redfish for Bmc {
         pem_cert: &str,
         database_id: &str,
     ) -> Result<Task, RedfishError> {
+        println!("<kcdPrint> add_secure_boot_certificate");
         self.s
             .add_secure_boot_certificate(pem_cert, database_id)
             .await
     }
 
     async fn get_secure_boot(&self) -> Result<SecureBoot, RedfishError> {
+        println!("<kcdPrint> get_secure_boot");
         self.s.get_secure_boot().await
     }
 
     async fn enable_secure_boot(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> enable_secure_boot");
         self.s.enable_secure_boot().await
     }
 
     async fn disable_secure_boot(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> disable_secure_boot");
         self.s.disable_secure_boot().await
     }
 
@@ -659,6 +709,7 @@ impl Redfish for Bmc {
         id: &str,
         port: Option<&str>,
     ) -> Result<NetworkDeviceFunction, RedfishError> {
+        println!("<kcdPrint> get_network_device_function");
         let Some(port) = port else {
             return Err(RedfishError::GenericError {
                 error: "Port is missing for Dell.".to_string(),
@@ -676,18 +727,22 @@ impl Redfish for Bmc {
         &self,
         chassis_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_network_device_functions");
         self.s.get_network_device_functions(chassis_id).await
     }
 
     async fn get_chassis_all(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_chassis_all");
         self.s.get_chassis_all().await
     }
 
     async fn get_chassis(&self, id: &str) -> Result<Chassis, RedfishError> {
+        println!("<kcdPrint> get_chassis");
         self.s.get_chassis(id).await
     }
 
     async fn get_chassis_assembly(&self, chassis_id: &str) -> Result<Assembly, RedfishError> {
+        println!("<kcdPrint> get_chassis_assembly");
         self.s.get_chassis_assembly(chassis_id).await
     }
 
@@ -695,6 +750,7 @@ impl Redfish for Bmc {
         &self,
         chassis_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_chassis_network_adapters");
         self.s.get_chassis_network_adapters(chassis_id).await
     }
 
@@ -703,6 +759,7 @@ impl Redfish for Bmc {
         chassis_id: &str,
         id: &str,
     ) -> Result<NetworkAdapter, RedfishError> {
+        println!("<kcdPrint> get_chassis_network_adapter");
         self.s.get_chassis_network_adapter(chassis_id, id).await
     }
 
@@ -710,6 +767,7 @@ impl Redfish for Bmc {
         &self,
         system_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_base_network_adapters");
         self.s.get_base_network_adapters(system_id).await
     }
 
@@ -718,6 +776,7 @@ impl Redfish for Bmc {
         system_id: &str,
         id: &str,
     ) -> Result<NetworkAdapter, RedfishError> {
+        println!("<kcdPrint> get_base_network_adapter");
         self.s.get_base_network_adapter(system_id, id).await
     }
 
@@ -726,6 +785,7 @@ impl Redfish for Bmc {
         chassis_id: &str,
         network_adapter: &str,
     ) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_ports");
         self.s.get_ports(chassis_id, network_adapter).await
     }
 
@@ -735,10 +795,12 @@ impl Redfish for Bmc {
         network_adapter: &str,
         id: &str,
     ) -> Result<crate::NetworkPort, RedfishError> {
+        println!("<kcdPrint> get_port");
         self.s.get_port(chassis_id, network_adapter, id).await
     }
 
     async fn get_manager_ethernet_interfaces(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_manager_ethernet_interfaces");
         self.s.get_manager_ethernet_interfaces().await
     }
 
@@ -746,10 +808,12 @@ impl Redfish for Bmc {
         &self,
         id: &str,
     ) -> Result<crate::EthernetInterface, RedfishError> {
+        println!("<kcdPrint> get_manager_ethernet_interface");
         self.s.get_manager_ethernet_interface(id).await
     }
 
     async fn get_system_ethernet_interfaces(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_system_ethernet_interfaces");
         self.s.get_system_ethernet_interfaces().await
     }
 
@@ -757,6 +821,7 @@ impl Redfish for Bmc {
         &self,
         id: &str,
     ) -> Result<crate::EthernetInterface, RedfishError> {
+        println!("<kcdPrint> get_system_ethernet_interface");
         self.s.get_system_ethernet_interface(id).await
     }
 
@@ -765,6 +830,7 @@ impl Redfish for Bmc {
         current_uefi_password: &str,
         new_uefi_password: &str,
     ) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> change_uefi_password");
         // The uefi password cant be changed if the host is in lockdown
         if self.is_lockdown().await? {
             return Err(RedfishError::Lockdown);
@@ -781,30 +847,37 @@ impl Redfish for Bmc {
     }
 
     async fn change_boot_order(&self, boot_array: Vec<String>) -> Result<(), RedfishError> {
+        println!("<kcdPrint> change_boot_order");
         self.s.change_boot_order(boot_array).await
     }
 
     async fn get_service_root(&self) -> Result<ServiceRoot, RedfishError> {
+        println!("<kcdPrint> get_service_root");
         self.s.get_service_root().await
     }
 
     async fn get_systems(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_systems");
         self.s.get_systems().await
     }
 
     async fn get_managers(&self) -> Result<Vec<String>, RedfishError> {
+        println!("<kcdPrint> get_managers");
         self.s.get_managers().await
     }
 
     async fn get_manager(&self) -> Result<Manager, RedfishError> {
+        println!("<kcdPrint> get_manager");
         self.s.get_manager().await
     }
 
     async fn bmc_reset_to_defaults(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> bmc_reset_to_defaults");
         self.s.bmc_reset_to_defaults().await
     }
 
     async fn get_job_state(&self, job_id: &str) -> Result<JobState, RedfishError> {
+        println!("<kcdPrint> get_job_state");
         let url = format!("Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{}", job_id);
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
@@ -848,10 +921,12 @@ impl Redfish for Bmc {
     }
 
     async fn get_collection(&self, id: ODataId) -> Result<Collection, RedfishError> {
+        println!("<kcdPrint> get_collection");
         self.s.get_collection(id).await
     }
 
     async fn get_resource(&self, id: ODataId) -> Result<Resource, RedfishError> {
+        println!("<kcdPrint> get_resource");
         self.s.get_resource(id).await
     }
 
@@ -861,6 +936,7 @@ impl Redfish for Bmc {
         &self,
         boot_interface_mac: &str,
     ) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> set_boot_order_dpu_first");
         let expected_boot_option_name: String = self
             .get_expected_dpu_boot_option_name(boot_interface_mac)
             .await?;
@@ -898,6 +974,7 @@ impl Redfish for Bmc {
         &self,
         current_uefi_password: &str,
     ) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> clear_uefi_password");
         match self.change_uefi_password(current_uefi_password, "").await {
             Ok(job_id) => return Ok(job_id),
             Err(e) => {
@@ -916,6 +993,7 @@ impl Redfish for Bmc {
     }
 
     async fn lockdown_bmc(&self, target: crate::EnabledDisabled) -> Result<(), RedfishError> {
+        println!("<kcdPrint> lockdown_bmc");
         use EnabledDisabled::*;
 
         // XE9680's can't PXE boot for some reason
@@ -932,6 +1010,7 @@ impl Redfish for Bmc {
     }
 
     async fn is_ipmi_over_lan_enabled(&self) -> Result<bool, RedfishError> {
+        println!("<kcdPrint> is_ipmi_over_lan_enabled");
         self.s.is_ipmi_over_lan_enabled().await
     }
 
@@ -939,6 +1018,7 @@ impl Redfish for Bmc {
         &self,
         target: crate::EnabledDisabled,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> enable_ipmi_over_lan");
         self.s.enable_ipmi_over_lan(target).await
     }
 
@@ -948,34 +1028,41 @@ impl Redfish for Bmc {
         targets: Vec<String>,
         transfer_protocol: TransferProtocolType,
     ) -> Result<Task, RedfishError> {
+        println!("<kcdPrint> update_firmware_simple_update");
         self.s
             .update_firmware_simple_update(image_uri, targets, transfer_protocol)
             .await
     }
 
     async fn enable_rshim_bmc(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> enable_rshim_bmc");
         self.s.enable_rshim_bmc().await
     }
 
     async fn clear_nvram(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> clear_nvram");
         self.s.clear_nvram().await
     }
 
     async fn get_nic_mode(&self) -> Result<Option<NicMode>, RedfishError> {
+        println!("<kcdPrint> get_nic_mode");
         self.s.get_nic_mode().await
     }
 
     async fn set_nic_mode(&self, mode: NicMode) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_nic_mode");
         self.s.set_nic_mode(mode).await
     }
 
     async fn enable_infinite_boot(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> enable_infinite_boot");
         let attrs: HashMap<String, serde_json::Value> =
             HashMap::from([("BootSeqRetry".to_string(), "Enabled".into())]);
         self.set_bios(attrs).await
     }
 
     async fn is_infinite_boot_enabled(&self) -> Result<Option<bool>, RedfishError> {
+        println!("<kcdPrint> is_infinite_boot_enabled");
         let url = format!("Systems/{}/Bios", self.s.system_id());
         let bios = self.bios().await?;
         let bios_attributes = jsonmap::get_object(&bios, "Attributes", &url)?;
@@ -988,18 +1075,22 @@ impl Redfish for Bmc {
     }
 
     async fn set_host_rshim(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_host_rshim");
         self.s.set_host_rshim(enabled).await
     }
 
     async fn get_host_rshim(&self) -> Result<Option<EnabledDisabled>, RedfishError> {
+        println!("<kcdPrint> get_host_rshim");
         self.s.get_host_rshim().await
     }
 
     async fn set_idrac_lockdown(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_idrac_lockdown");
         self.set_idrac_lockdown(enabled).await
     }
 
     async fn get_boss_controller(&self) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> get_boss_controller");
         self.get_boss_controller().await
     }
 
@@ -1007,6 +1098,7 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
     ) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> decommission_storage_controller");
         Ok(Some(self.decommission_controller(controller_id).await?))
     }
 
@@ -1015,6 +1107,7 @@ impl Redfish for Bmc {
         controller_id: &str,
         volume_name: &str,
     ) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> create_storage_volume");
         let drives = self.get_storage_drives(controller_id).await?;
 
         let raid_type = match drives.as_array().map(|a| a.len()).unwrap_or(0) {
@@ -1036,6 +1129,7 @@ impl Redfish for Bmc {
     }
 
     async fn is_boot_order_setup(&self, boot_interface_mac: &str) -> Result<bool, RedfishError> {
+        println!("<kcdPrint> is_boot_order_setup");
         let (expected, actual) = self
             .get_expected_and_actual_first_boot_option(boot_interface_mac)
             .await?;
@@ -1043,11 +1137,13 @@ impl Redfish for Bmc {
     }
 
     async fn is_bios_setup(&self, boot_interface_mac: Option<&str>) -> Result<bool, RedfishError> {
+        println!("<kcdPrint> is_bios_setup");
         let diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
         Ok(diffs.is_empty())
     }
 
     async fn get_component_integrities(&self) -> Result<ComponentIntegrities, RedfishError> {
+        println!("<kcdPrint> get_component_integrities");
         self.s.get_component_integrities().await
     }
 
@@ -1055,6 +1151,7 @@ impl Redfish for Bmc {
         &self,
         componnent_integrity_id: &str,
     ) -> Result<crate::model::software_inventory::SoftwareInventory, RedfishError> {
+        println!("<kcdPrint> get_firmware_for_component");
         self.s
             .get_firmware_for_component(componnent_integrity_id)
             .await
@@ -1064,6 +1161,7 @@ impl Redfish for Bmc {
         &self,
         url: &str,
     ) -> Result<crate::model::component_integrity::CaCertificate, RedfishError> {
+        println!("<kcdPrint> get_component_ca_certificate");
         self.s.get_component_ca_certificate(url).await
     }
 
@@ -1072,6 +1170,7 @@ impl Redfish for Bmc {
         url: &str,
         nonce: &str,
     ) -> Result<Task, RedfishError> {
+        println!("<kcdPrint> trigger_evidence_collection");
         self.s.trigger_evidence_collection(url, nonce).await
     }
 
@@ -1079,6 +1178,7 @@ impl Redfish for Bmc {
         &self,
         url: &str,
     ) -> Result<crate::model::component_integrity::Evidence, RedfishError> {
+        println!("<kcdPrint> get_evidence");
         self.s.get_evidence(url).await
     }
 
@@ -1086,10 +1186,12 @@ impl Redfish for Bmc {
         &self,
         level: HostPrivilegeLevel,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_host_privilege_level");
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_utc_timezone");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1103,6 +1205,7 @@ impl Redfish for Bmc {
     }
 
     async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> disable_psu_hot_spare");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1118,6 +1221,7 @@ impl Redfish for Bmc {
 
 impl Bmc {
     pub fn new(s: RedfishStandard) -> Result<Bmc, RedfishError> {
+        println!("<kcdPrint> new");
         Ok(Bmc { s })
     }
 
@@ -1126,6 +1230,7 @@ impl Bmc {
         &self,
         boot_interface_mac: Option<&str>,
     ) -> Result<Vec<MachineSetupDiff>, RedfishError> {
+        println!("<kcdPrint> diff_bios_bmc_attr");
         let mut diffs = vec![];
 
         let bios = self.s.bios_attributes().await?;
@@ -1268,6 +1373,7 @@ impl Bmc {
     }
 
     async fn perform_ac_power_cycle(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> perform_ac_power_cycle");
         self.clear_pending().await?;
 
         // Set PowerCycleRequest in BIOS settings
@@ -1314,6 +1420,7 @@ impl Bmc {
 
     // No changes can be applied if there are pending jobs
     async fn delete_job_queue(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> delete_job_queue");
         // The queue can't be cleared if system lockdown is enabled
         if self.is_lockdown().await? {
             return Err(RedfishError::Lockdown);
@@ -1330,6 +1437,7 @@ impl Bmc {
 
     // is_lockdown checks if system lockdown is enabled.
     async fn is_lockdown(&self) -> Result<bool, RedfishError> {
+        println!("<kcdPrint> is_lockdown");
         let (attrs, url) = self.manager_attributes().await?;
         let system_lockdown = jsonmap::get_str(&attrs, "Lockdown.1.SystemLockdown", &url)?;
 
@@ -1342,6 +1450,7 @@ impl Bmc {
         entry: dell::BootDevices,
         once: bool,
     ) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_boot_first");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset,
         };
@@ -1370,6 +1479,7 @@ impl Bmc {
     }
 
     async fn set_idrac_lockdown(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
+        println!("<kcdPrint> set_idrac_lockdown");
         let manager_id: &str = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1387,6 +1497,7 @@ impl Bmc {
     }
 
     async fn enable_bmc_lockdown(&self, entry: dell::BootDevices) -> Result<(), RedfishError> {
+        println!("<kcdPrint> enable_bmc_lockdown");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset,
         };
@@ -1432,6 +1543,7 @@ impl Bmc {
     }
 
     async fn disable_bios_lockdown(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> disable_bios_lockdown");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -1465,6 +1577,7 @@ impl Bmc {
     }
 
     async fn disable_bmc_lockdown(&self, entry: dell::BootDevices) -> Result<(), RedfishError> {
+        println!("<kcdPrint> disable_bmc_lockdown");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::Immediate, // bmc settings don't require reboot
         };
@@ -1491,6 +1604,7 @@ impl Bmc {
     }
 
     async fn setup_bmc_remote_access(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> setup_bmc_remote_access");
         // Try the regular Attributes path first (iDRAC 9 and earlier)
         match self.setup_bmc_remote_access_standard().await {
             Ok(()) => return Ok(()),
@@ -1509,6 +1623,7 @@ impl Bmc {
 
     /// Setup BMC remote access via standard Attributes path (iDRAC 9 and earlier).
     async fn setup_bmc_remote_access_standard(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> setup_bmc_remote_access_standard");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::Immediate,
         };
@@ -1540,6 +1655,7 @@ impl Bmc {
 
     /// Setup BMC remote access via OEM DellAttributes path (iDRAC 10).
     async fn setup_bmc_remote_access_oem(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> setup_bmc_remote_access_oem");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1557,6 +1673,7 @@ impl Bmc {
     }
 
     async fn bmc_remote_access_status(&self) -> Result<Status, RedfishError> {
+        println!("<kcdPrint> bmc_remote_access_status");
         let (attrs, _) = self.manager_attributes().await?;
         let expected = vec![
             // "any" means any value counts as correctly disabled
@@ -1597,6 +1714,7 @@ impl Bmc {
     }
 
     async fn bios_serial_console_status(&self) -> Result<Status, RedfishError> {
+        println!("<kcdPrint> bios_serial_console_status");
         let mut message = String::new();
 
         // Start with true, then check every value to see whether it means things are not setup
@@ -1722,6 +1840,7 @@ impl Bmc {
 
     // dell stores the sel as part of the manager
     async fn get_system_event_log(&self) -> Result<Vec<LogEntry>, RedfishError> {
+        println!("<kcdPrint> get_system_event_log");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/LogServices/Sel/Entries");
         let (_status_code, log_entry_collection): (_, LogEntryCollection) =
@@ -1735,6 +1854,7 @@ impl Bmc {
     async fn manager_attributes(
         &self,
     ) -> Result<(serde_json::Map<String, serde_json::Value>, String), RedfishError> {
+        println!("<kcdPrint> manager_attributes");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
         let (_status_code, mut body): (_, HashMap<String, serde_json::Value>) =
@@ -1745,6 +1865,7 @@ impl Bmc {
 
     /// Extra Dell-specific attributes we need to set that are not BIOS attributes
     async fn machine_setup_oem(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> machine_setup_oem");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1767,6 +1888,7 @@ impl Bmc {
     }
 
     async fn manager_dell_oem_attributes(&self) -> Result<serde_json::Value, RedfishError> {
+        println!("<kcdPrint> manager_dell_oem_attributes");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
         let (_status_code, mut body): (_, HashMap<String, serde_json::Value>) =
@@ -1781,6 +1903,7 @@ impl Bmc {
     // TPM is enabled by default so we never call this.
     #[allow(dead_code)]
     async fn enable_tpm(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> enable_tpm");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -1804,6 +1927,7 @@ impl Bmc {
     // Lenovo does not support disabling TPM2.0
     #[allow(dead_code)]
     async fn disable_tpm(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> disable_tpm");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -1824,6 +1948,7 @@ impl Bmc {
     }
 
     pub async fn create_bios_config_job(&self) -> Result<String, RedfishError> {
+        println!("<kcdPrint> create_bios_config_job");
         let url = "Managers/iDRAC.Embedded.1/Oem/Dell/Jobs";
 
         let mut arg = HashMap::new();
@@ -1842,6 +1967,7 @@ impl Bmc {
         &self,
         nic_slot: &str,
     ) -> Result<dell::MachineBiosAttrs, RedfishError> {
+        println!("<kcdPrint> machine_setup_attrs");
         let curr_bios_attributes = self.s.bios_attributes().await?;
 
         // RedirAfterBoot: Not available in iDRAC 10
@@ -1911,6 +2037,7 @@ impl Bmc {
         &self,
         current_uefi_password: &str,
     ) -> Result<String, RedfishError> {
+        println!("<kcdPrint> clear_uefi_password_via_import");
         let system_configuration = SystemConfiguration {
             shutdown_type: "Forced".to_string(),
             share_parameters: ShareParameters {
@@ -1929,6 +2056,7 @@ impl Bmc {
         url: &str,
         resp_headers: HeaderMap,
     ) -> Result<String, RedfishError> {
+        println!("<kcdPrint> parse_job_id_from_response_headers");
         let key = "location";
         Ok(resp_headers
             .get(key)
@@ -1957,6 +2085,7 @@ impl Bmc {
         &self,
         system_configuration: SystemConfiguration,
     ) -> Result<String, RedfishError> {
+        println!("<kcdPrint> import_system_configuration");
         let url = "Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ImportSystemConfiguration";
         let (_status_code, _resp_body, resp_headers): (
             _,
@@ -1985,6 +2114,7 @@ impl Bmc {
         &self,
         boot_interface_mac_address: &str,
     ) -> Result<NetworkDeviceFunction, RedfishError> {
+        println!("<kcdPrint> get_dpu_nw_device_function");
         let chassis = self.get_chassis(self.s.system_id()).await?;
         let na_id = match chassis.network_adapters {
             Some(id) => id,
@@ -2044,6 +2174,7 @@ impl Bmc {
         &self,
         mac_address: &str,
     ) -> Result<serde_json::Map<String, Value>, RedfishError> {
+        println!("<kcdPrint> get_dell_nic_info");
         let nw_device_function = self.get_dpu_nw_device_function(mac_address).await?;
 
         let oem = nw_device_function
@@ -2074,6 +2205,7 @@ impl Bmc {
 
     // Returns a string like "NIC.Slot.5-1"
     async fn dpu_nic_slot(&self, mac_address: &str) -> Result<String, RedfishError> {
+        println!("<kcdPrint> dpu_nic_slot");
         let dell_nic_info = self.get_dell_nic_info(mac_address).await?;
 
         let nic_slot = dell_nic_info
@@ -2088,6 +2220,7 @@ impl Bmc {
     }
 
     async fn get_boss_controller(&self) -> Result<Option<String>, RedfishError> {
+        println!("<kcdPrint> get_boss_controller");
         let url = "Systems/System.Embedded.1/Storage";
         let (_status_code, storage_collection): (_, StorageCollection) =
             self.s.client.get(url).await?;
@@ -2112,6 +2245,7 @@ impl Bmc {
     }
 
     async fn decommission_controller(&self, controller_id: &str) -> Result<String, RedfishError> {
+        println!("<kcdPrint> decommission_controller");
         // wait for the lifecycle controller status to become Ready before decomissioning the boss controller
         // https://github.com/dell/idrac-Redfish-Scripting/issues/323
         self.lifecycle_controller_is_ready().await?;
@@ -2127,6 +2261,7 @@ impl Bmc {
     }
 
     async fn get_storage_drives(&self, controller_id: &str) -> Result<Value, RedfishError> {
+        println!("<kcdPrint> get_storage_drives");
         let url = format!("Systems/System.Embedded.1/Storage/{controller_id}");
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
@@ -2140,6 +2275,7 @@ impl Bmc {
         raid_type: &str,
         drive_info: Value,
     ) -> Result<String, RedfishError> {
+        println!("<kcdPrint> create_storage_volume");
         if volume_name.len() > 15 || volume_name.is_empty() {
             return Err(RedfishError::GenericError {
                 error: format!(
@@ -2165,6 +2301,7 @@ impl Bmc {
     }
 
     async fn get_lifecycle_controller_status(&self) -> Result<String, RedfishError> {
+        println!("<kcdPrint> get_lifecycle_controller_status");
         let manager_id = self.s.manager_id();
         let url = format!(
             "Managers/{manager_id}/Oem/Dell/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus"
@@ -2189,6 +2326,7 @@ impl Bmc {
     }
 
     async fn lifecycle_controller_is_ready(&self) -> Result<(), RedfishError> {
+        println!("<kcdPrint> lifecycle_controller_is_ready");
         let lc_status = self.get_lifecycle_controller_status().await?;
         if lc_status == "Ready" {
             return Ok(());
@@ -2204,6 +2342,7 @@ impl Bmc {
         &self,
         boot_interface_mac: &str,
     ) -> Result<String, RedfishError> {
+        println!("<kcdPrint> get_expected_dpu_boot_option_name");
         let dell_nic_info = self.get_dell_nic_info(boot_interface_mac).await?;
 
         let device_description = dell_nic_info
@@ -2218,6 +2357,7 @@ impl Bmc {
     }
 
     async fn get_boot_order(&self) -> Result<Vec<BootOption>, RedfishError> {
+        println!("<kcdPrint> get_boot_order");
         let boot_options = self.get_boot_options().await?;
         let mut boot_order: Vec<BootOption> = Vec::new();
         for boot_option in boot_options.members.iter() {
@@ -2236,6 +2376,7 @@ impl Bmc {
         &self,
         boot_interface_mac: &str,
     ) -> Result<(Option<String>, Option<String>), RedfishError> {
+        println!("<kcdPrint> get_expected_and_actual_first_boot_option");
         let expected_first_boot_option = Some(
             self.get_expected_dpu_boot_option_name(boot_interface_mac)
                 .await?,
@@ -2263,6 +2404,7 @@ struct Empty {}
 
 impl UpdateParameters {
     pub fn new(reboot_immediate: bool) -> UpdateParameters {
+        println!("<kcdPrint> UpdateParameters::new");
         let apply_time = match reboot_immediate {
             true => "Immediate",
             false => "OnReset",

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -252,9 +252,7 @@ impl Redfish for Bmc {
                 (slot, true)
             }
             // Zero-DPU case
-            None => {
-                ("".to_string(), false)
-            }
+            None => ("".to_string(), false),
         };
 
         // dell idrac requires applying all bios settings at once.
@@ -291,7 +289,9 @@ impl Redfish for Bmc {
         let url = format!("Systems/{}/Bios/Settings/", self.s.system_id());
         let bios_job_id = match self.s.client.patch(&url, set_machine_attrs).await? {
             (_, Some(headers)) => {
-                let jid = self.parse_job_id_from_response_headers(&url, headers).await?;
+                let jid = self
+                    .parse_job_id_from_response_headers(&url, headers)
+                    .await?;
                 Some(jid)
             }
             (_, None) => {
@@ -303,12 +303,10 @@ impl Redfish for Bmc {
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
-            println!(
-                "<kcdTaskIDs> machine_setup success, returning bios_job_id={:?}",
-                bios_job_id
-            );
             Ok(bios_job_id)
         } else {
+            // Usually a missing DPU is an error, but for zero-dpu it isn't
+            // Tell the caller and let them decide
             Err(RedfishError::NoDpu)
         }
     }
@@ -853,10 +851,6 @@ impl Redfish for Bmc {
             state => state,
         };
 
-        println!(
-            "<kcdTaskIDs> get_job_state job_id={} returning state={:?}",
-            job_id, job_state
-        );
         Ok(job_state)
     }
 

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -74,7 +74,6 @@ impl Redfish for Bmc {
         password: &str,
         role_id: RoleId,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> create_user");
         // Find an unused ID
         // 'root' is typically ID 2 on an iDrac, and ID 1 might be special
         let mut account_id = 3;
@@ -104,17 +103,14 @@ impl Redfish for Bmc {
     }
 
     async fn delete_user(&self, username: &str) -> Result<(), RedfishError> {
-        println!("<kcdPrint> delete_user");
         self.s.delete_user(username).await
     }
 
     async fn change_username(&self, old_name: &str, new_name: &str) -> Result<(), RedfishError> {
-        println!("<kcdPrint> change_username");
         self.s.change_username(old_name, new_name).await
     }
 
     async fn change_password(&self, username: &str, new_pass: &str) -> Result<(), RedfishError> {
-        println!("<kcdPrint> change_password");
         self.s.change_password(username, new_pass).await
     }
 
@@ -123,27 +119,22 @@ impl Redfish for Bmc {
         account_id: &str,
         new_pass: &str,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> change_password_by_id");
         self.s.change_password_by_id(account_id, new_pass).await
     }
 
     async fn get_accounts(&self) -> Result<Vec<ManagerAccount>, RedfishError> {
-        println!("<kcdPrint> get_accounts");
         self.s.get_accounts().await
     }
 
     async fn get_power_state(&self) -> Result<PowerState, RedfishError> {
-        println!("<kcdPrint> get_power_state");
         self.s.get_power_state().await
     }
 
     async fn get_power_metrics(&self) -> Result<Power, RedfishError> {
-        println!("<kcdPrint> get_power_metrics");
         self.s.get_power_metrics().await
     }
 
     async fn power(&self, action: SystemPowerControl) -> Result<(), RedfishError> {
-        println!("<kcdPrint> power");
         if action == SystemPowerControl::ACPowercycle {
             let is_lockdown = self.is_lockdown().await?;
             let bios_attrs = self.s.bios_attributes().await?;
@@ -164,12 +155,10 @@ impl Redfish for Bmc {
     }
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
-        println!("<kcdPrint> ac_powercycle_supported_by_power");
         true
     }
 
     async fn bmc_reset(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> bmc_reset");
         self.s.bmc_reset().await
     }
 
@@ -178,27 +167,22 @@ impl Redfish for Bmc {
         chassis_id: &str,
         reset_type: SystemPowerControl,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> chassis_reset");
         self.s.chassis_reset(chassis_id, reset_type).await
     }
 
     async fn get_thermal_metrics(&self) -> Result<Thermal, RedfishError> {
-        println!("<kcdPrint> get_thermal_metrics");
         self.s.get_thermal_metrics().await
     }
 
     async fn get_gpu_sensors(&self) -> Result<Vec<GPUSensors>, RedfishError> {
-        println!("<kcdPrint> get_gpu_sensors");
         self.s.get_gpu_sensors().await
     }
 
     async fn get_update_service(&self) -> Result<UpdateService, RedfishError> {
-        println!("<kcdPrint> get_update_service");
         self.s.get_update_service().await
     }
 
     async fn get_system_event_log(&self) -> Result<Vec<LogEntry>, RedfishError> {
-        println!("<kcdPrint> get_system_event_log");
         self.get_system_event_log().await
     }
 
@@ -206,18 +190,15 @@ impl Redfish for Bmc {
         &self,
         from: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<Vec<LogEntry>, RedfishError> {
-        println!("<kcdPrint> get_bmc_event_log");
         // Different Dell timestamp formats (UTC-5, DST, etc..) are making filtering and comparing very difficult
         self.s.get_bmc_event_log(from).await
     }
 
     async fn get_drives_metrics(&self) -> Result<Vec<Drives>, RedfishError> {
-        println!("<kcdPrint> get_drives_metrics");
         self.s.get_drives_metrics().await
     }
 
     async fn bios(&self) -> Result<HashMap<String, serde_json::Value>, RedfishError> {
-        println!("<kcdPrint> bios");
         self.s.bios().await
     }
 
@@ -225,7 +206,6 @@ impl Redfish for Bmc {
         &self,
         values: HashMap<String, serde_json::Value>,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_bios");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -244,12 +224,10 @@ impl Redfish for Bmc {
     }
 
     async fn reset_bios(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> reset_bios");
         self.s.factory_reset_bios().await
     }
 
     async fn get_base_mac_address(&self) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> get_base_mac_address");
         self.s.get_base_mac_address().await
     }
 
@@ -262,9 +240,7 @@ impl Redfish for Bmc {
         >,
         selected_profile: BiosProfileType,
     ) -> Result<Option<String>, RedfishError> {
-        println!("<kcdTaskIDs> machine_setup entry");
         self.delete_job_queue().await?;
-        println!("<kcdTaskIDs> machine_setup job queue deleted");
 
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
@@ -272,19 +248,16 @@ impl Redfish for Bmc {
 
         let (nic_slot, has_dpu) = match boot_interface_mac {
             Some(mac) => {
-                println!("<kcdTaskIDs> machine_setup resolving nic_slot for mac {}", mac);
                 let slot: String = self.dpu_nic_slot(mac).await?;
                 (slot, true)
             }
             // Zero-DPU case
             None => {
-                println!("<kcdTaskIDs> machine_setup zero-DPU case");
                 ("".to_string(), false)
             }
         };
 
         // dell idrac requires applying all bios settings at once.
-        println!("<kcdTaskIDs> machine_setup fetching machine_setup_attrs");
         let machine_settings = self.machine_setup_attrs(&nic_slot).await?;
         let set_machine_attrs = dell::SetBiosAttrs {
             redfish_settings_apply_time: apply_time,
@@ -316,22 +289,17 @@ impl Redfish for Bmc {
         }
 
         let url = format!("Systems/{}/Bios/Settings/", self.s.system_id());
-        println!("<kcdTaskIDs> machine_setup PATCHing BIOS Settings url={}", url);
         let bios_job_id = match self.s.client.patch(&url, set_machine_attrs).await? {
             (_, Some(headers)) => {
                 let jid = self.parse_job_id_from_response_headers(&url, headers).await?;
-                println!("<kcdTaskIDs> machine_setup BIOS PATCH returned task/job id={}", jid);
                 Some(jid)
             }
             (_, None) => {
-                println!("<kcdTaskIDs> machine_setup BIOS PATCH returned no Location header");
                 return Err(RedfishError::NoHeader);
             }
         };
 
-        println!("<kcdTaskIDs> machine_setup running machine_setup_oem");
         self.machine_setup_oem().await?;
-        println!("<kcdTaskIDs> machine_setup running setup_bmc_remote_access");
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
@@ -341,7 +309,6 @@ impl Redfish for Bmc {
             );
             Ok(bios_job_id)
         } else {
-            println!("<kcdTaskIDs> machine_setup NoDpu (zero-DPU)");
             Err(RedfishError::NoDpu)
         }
     }
@@ -350,7 +317,6 @@ impl Redfish for Bmc {
         &self,
         boot_interface_mac: Option<&str>,
     ) -> Result<MachineSetupStatus, RedfishError> {
-        println!("<kcdPrint> machine_setup_status");
         // Check BIOS and BMC attributes
         let mut diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
 
@@ -385,7 +351,6 @@ impl Redfish for Bmc {
     /// iDRAC does not suport changing password policy. They support IP blocking instead.
     /// https://github.com/dell/iDRAC-Redfish-Scripting/issues/295
     async fn set_machine_password_policy(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_machine_password_policy");
         // These are all password policy a Dell has, and they are all read only.
         // Redfish will reject attempts to modify them.
         // - AccountLockoutThreshold
@@ -396,7 +361,6 @@ impl Redfish for Bmc {
     }
 
     async fn lockdown(&self, target: EnabledDisabled) -> Result<(), RedfishError> {
-        println!("<kcdPrint> lockdown");
         use EnabledDisabled::*;
         // XE9680's can't PXE boot for some reason
         let system = self.s.get_system().await?;
@@ -418,7 +382,6 @@ impl Redfish for Bmc {
     }
 
     async fn lockdown_status(&self) -> Result<Status, RedfishError> {
-        println!("<kcdPrint> lockdown_status");
         let mut message = String::new();
         let enabled = EnabledDisabled::Enabled.to_string();
         let disabled = EnabledDisabled::Disabled.to_string();
@@ -448,7 +411,6 @@ impl Redfish for Bmc {
     }
 
     async fn setup_serial_console(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> setup_serial_console");
         self.delete_job_queue().await?;
 
         self.setup_bmc_remote_access().await?;
@@ -507,7 +469,6 @@ impl Redfish for Bmc {
     }
 
     async fn serial_console_status(&self) -> Result<Status, RedfishError> {
-        println!("<kcdPrint> serial_console_status");
         let Status {
             status: remote_access_status,
             message: remote_access_message,
@@ -532,17 +493,14 @@ impl Redfish for Bmc {
     }
 
     async fn get_boot_options(&self) -> Result<BootOptions, RedfishError> {
-        println!("<kcdPrint> get_boot_options");
         self.s.get_boot_options().await
     }
 
     async fn get_boot_option(&self, option_id: &str) -> Result<BootOption, RedfishError> {
-        println!("<kcdPrint> get_boot_option");
         self.s.get_boot_option(option_id).await
     }
 
     async fn boot_once(&self, target: Boot) -> Result<(), RedfishError> {
-        println!("<kcdPrint> boot_once");
         match target {
             Boot::Pxe => self.set_boot_first(dell::BootDevices::PXE, true).await,
             Boot::HardDisk => self.set_boot_first(dell::BootDevices::HDD, true).await,
@@ -553,7 +511,6 @@ impl Redfish for Bmc {
     }
 
     async fn boot_first(&self, target: Boot) -> Result<(), RedfishError> {
-        println!("<kcdPrint> boot_first");
         match target {
             Boot::Pxe => self.set_boot_first(dell::BootDevices::PXE, false).await,
             Boot::HardDisk => self.set_boot_first(dell::BootDevices::HDD, false).await,
@@ -564,7 +521,6 @@ impl Redfish for Bmc {
     }
 
     async fn clear_tpm(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> clear_tpm");
         self.delete_job_queue().await?;
 
         let apply_time = dell::SetSettingsApplyTime {
@@ -587,17 +543,14 @@ impl Redfish for Bmc {
     }
 
     async fn pending(&self) -> Result<HashMap<String, serde_json::Value>, RedfishError> {
-        println!("<kcdPrint> pending");
         self.s.pending().await
     }
 
     async fn clear_pending(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> clear_pending");
         self.delete_job_queue().await
     }
 
     async fn pcie_devices(&self) -> Result<Vec<PCIeDevice>, RedfishError> {
-        println!("<kcdPrint> pcie_devices");
         self.s.pcie_devices().await
     }
 
@@ -605,7 +558,6 @@ impl Redfish for Bmc {
         &self,
         firmware: tokio::fs::File,
     ) -> Result<crate::model::task::Task, RedfishError> {
-        println!("<kcdPrint> update_firmware");
         self.s.update_firmware(firmware).await
     }
 
@@ -617,7 +569,6 @@ impl Redfish for Bmc {
         timeout: Duration,
         _component_type: ComponentType,
     ) -> Result<String, RedfishError> {
-        println!("<kcdPrint> update_firmware_multipart");
         let firmware = File::open(&filename)
             .await
             .map_err(|e| RedfishError::FileError(format!("Could not open file: {e}")))?;
@@ -653,27 +604,22 @@ impl Redfish for Bmc {
     }
 
     async fn get_tasks(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_tasks");
         self.s.get_tasks().await
     }
 
     async fn get_task(&self, id: &str) -> Result<crate::model::task::Task, RedfishError> {
-        println!("<kcdPrint> get_task");
         self.s.get_task(id).await
     }
 
     async fn get_firmware(&self, id: &str) -> Result<SoftwareInventory, RedfishError> {
-        println!("<kcdPrint> get_firmware");
         self.s.get_firmware(id).await
     }
 
     async fn get_software_inventories(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_software_inventories");
         self.s.get_software_inventories().await
     }
 
     async fn get_system(&self) -> Result<ComputerSystem, RedfishError> {
-        println!("<kcdPrint> get_system");
         self.s.get_system().await
     }
 
@@ -682,7 +628,6 @@ impl Redfish for Bmc {
         database_id: &str,
         certificate_id: &str,
     ) -> Result<Certificate, RedfishError> {
-        println!("<kcdPrint> get_secure_boot_certificate");
         self.s
             .get_secure_boot_certificate(database_id, certificate_id)
             .await
@@ -692,7 +637,6 @@ impl Redfish for Bmc {
         &self,
         database_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_secure_boot_certificates");
         self.s.get_secure_boot_certificates(database_id).await
     }
 
@@ -701,24 +645,20 @@ impl Redfish for Bmc {
         pem_cert: &str,
         database_id: &str,
     ) -> Result<Task, RedfishError> {
-        println!("<kcdPrint> add_secure_boot_certificate");
         self.s
             .add_secure_boot_certificate(pem_cert, database_id)
             .await
     }
 
     async fn get_secure_boot(&self) -> Result<SecureBoot, RedfishError> {
-        println!("<kcdPrint> get_secure_boot");
         self.s.get_secure_boot().await
     }
 
     async fn enable_secure_boot(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> enable_secure_boot");
         self.s.enable_secure_boot().await
     }
 
     async fn disable_secure_boot(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> disable_secure_boot");
         self.s.disable_secure_boot().await
     }
 
@@ -728,7 +668,6 @@ impl Redfish for Bmc {
         id: &str,
         port: Option<&str>,
     ) -> Result<NetworkDeviceFunction, RedfishError> {
-        println!("<kcdPrint> get_network_device_function");
         let Some(port) = port else {
             return Err(RedfishError::GenericError {
                 error: "Port is missing for Dell.".to_string(),
@@ -746,22 +685,18 @@ impl Redfish for Bmc {
         &self,
         chassis_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_network_device_functions");
         self.s.get_network_device_functions(chassis_id).await
     }
 
     async fn get_chassis_all(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_chassis_all");
         self.s.get_chassis_all().await
     }
 
     async fn get_chassis(&self, id: &str) -> Result<Chassis, RedfishError> {
-        println!("<kcdPrint> get_chassis");
         self.s.get_chassis(id).await
     }
 
     async fn get_chassis_assembly(&self, chassis_id: &str) -> Result<Assembly, RedfishError> {
-        println!("<kcdPrint> get_chassis_assembly");
         self.s.get_chassis_assembly(chassis_id).await
     }
 
@@ -769,7 +704,6 @@ impl Redfish for Bmc {
         &self,
         chassis_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_chassis_network_adapters");
         self.s.get_chassis_network_adapters(chassis_id).await
     }
 
@@ -778,7 +712,6 @@ impl Redfish for Bmc {
         chassis_id: &str,
         id: &str,
     ) -> Result<NetworkAdapter, RedfishError> {
-        println!("<kcdPrint> get_chassis_network_adapter");
         self.s.get_chassis_network_adapter(chassis_id, id).await
     }
 
@@ -786,7 +719,6 @@ impl Redfish for Bmc {
         &self,
         system_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_base_network_adapters");
         self.s.get_base_network_adapters(system_id).await
     }
 
@@ -795,7 +727,6 @@ impl Redfish for Bmc {
         system_id: &str,
         id: &str,
     ) -> Result<NetworkAdapter, RedfishError> {
-        println!("<kcdPrint> get_base_network_adapter");
         self.s.get_base_network_adapter(system_id, id).await
     }
 
@@ -804,7 +735,6 @@ impl Redfish for Bmc {
         chassis_id: &str,
         network_adapter: &str,
     ) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_ports");
         self.s.get_ports(chassis_id, network_adapter).await
     }
 
@@ -814,12 +744,10 @@ impl Redfish for Bmc {
         network_adapter: &str,
         id: &str,
     ) -> Result<crate::NetworkPort, RedfishError> {
-        println!("<kcdPrint> get_port");
         self.s.get_port(chassis_id, network_adapter, id).await
     }
 
     async fn get_manager_ethernet_interfaces(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_manager_ethernet_interfaces");
         self.s.get_manager_ethernet_interfaces().await
     }
 
@@ -827,12 +755,10 @@ impl Redfish for Bmc {
         &self,
         id: &str,
     ) -> Result<crate::EthernetInterface, RedfishError> {
-        println!("<kcdPrint> get_manager_ethernet_interface");
         self.s.get_manager_ethernet_interface(id).await
     }
 
     async fn get_system_ethernet_interfaces(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_system_ethernet_interfaces");
         self.s.get_system_ethernet_interfaces().await
     }
 
@@ -840,7 +766,6 @@ impl Redfish for Bmc {
         &self,
         id: &str,
     ) -> Result<crate::EthernetInterface, RedfishError> {
-        println!("<kcdPrint> get_system_ethernet_interface");
         self.s.get_system_ethernet_interface(id).await
     }
 
@@ -849,7 +774,6 @@ impl Redfish for Bmc {
         current_uefi_password: &str,
         new_uefi_password: &str,
     ) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> change_uefi_password");
         // The uefi password cant be changed if the host is in lockdown
         if self.is_lockdown().await? {
             return Err(RedfishError::Lockdown);
@@ -866,37 +790,30 @@ impl Redfish for Bmc {
     }
 
     async fn change_boot_order(&self, boot_array: Vec<String>) -> Result<(), RedfishError> {
-        println!("<kcdPrint> change_boot_order");
         self.s.change_boot_order(boot_array).await
     }
 
     async fn get_service_root(&self) -> Result<ServiceRoot, RedfishError> {
-        println!("<kcdPrint> get_service_root");
         self.s.get_service_root().await
     }
 
     async fn get_systems(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_systems");
         self.s.get_systems().await
     }
 
     async fn get_managers(&self) -> Result<Vec<String>, RedfishError> {
-        println!("<kcdPrint> get_managers");
         self.s.get_managers().await
     }
 
     async fn get_manager(&self) -> Result<Manager, RedfishError> {
-        println!("<kcdPrint> get_manager");
         self.s.get_manager().await
     }
 
     async fn bmc_reset_to_defaults(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> bmc_reset_to_defaults");
         self.s.bmc_reset_to_defaults().await
     }
 
     async fn get_job_state(&self, job_id: &str) -> Result<JobState, RedfishError> {
-        println!("<kcdTaskIDs> get_job_state job_id={}", job_id);
         let url = format!("Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{}", job_id);
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
@@ -944,12 +861,10 @@ impl Redfish for Bmc {
     }
 
     async fn get_collection(&self, id: ODataId) -> Result<Collection, RedfishError> {
-        println!("<kcdPrint> get_collection");
         self.s.get_collection(id).await
     }
 
     async fn get_resource(&self, id: ODataId) -> Result<Resource, RedfishError> {
-        println!("<kcdPrint> get_resource");
         self.s.get_resource(id).await
     }
 
@@ -959,7 +874,6 @@ impl Redfish for Bmc {
         &self,
         boot_interface_mac: &str,
     ) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> set_boot_order_dpu_first");
         let expected_boot_option_name: String = self
             .get_expected_dpu_boot_option_name(boot_interface_mac)
             .await?;
@@ -997,7 +911,6 @@ impl Redfish for Bmc {
         &self,
         current_uefi_password: &str,
     ) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> clear_uefi_password");
         match self.change_uefi_password(current_uefi_password, "").await {
             Ok(job_id) => return Ok(job_id),
             Err(e) => {
@@ -1016,7 +929,6 @@ impl Redfish for Bmc {
     }
 
     async fn lockdown_bmc(&self, target: crate::EnabledDisabled) -> Result<(), RedfishError> {
-        println!("<kcdPrint> lockdown_bmc");
         use EnabledDisabled::*;
 
         // XE9680's can't PXE boot for some reason
@@ -1033,7 +945,6 @@ impl Redfish for Bmc {
     }
 
     async fn is_ipmi_over_lan_enabled(&self) -> Result<bool, RedfishError> {
-        println!("<kcdPrint> is_ipmi_over_lan_enabled");
         self.s.is_ipmi_over_lan_enabled().await
     }
 
@@ -1041,7 +952,6 @@ impl Redfish for Bmc {
         &self,
         target: crate::EnabledDisabled,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> enable_ipmi_over_lan");
         self.s.enable_ipmi_over_lan(target).await
     }
 
@@ -1051,41 +961,34 @@ impl Redfish for Bmc {
         targets: Vec<String>,
         transfer_protocol: TransferProtocolType,
     ) -> Result<Task, RedfishError> {
-        println!("<kcdPrint> update_firmware_simple_update");
         self.s
             .update_firmware_simple_update(image_uri, targets, transfer_protocol)
             .await
     }
 
     async fn enable_rshim_bmc(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> enable_rshim_bmc");
         self.s.enable_rshim_bmc().await
     }
 
     async fn clear_nvram(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> clear_nvram");
         self.s.clear_nvram().await
     }
 
     async fn get_nic_mode(&self) -> Result<Option<NicMode>, RedfishError> {
-        println!("<kcdPrint> get_nic_mode");
         self.s.get_nic_mode().await
     }
 
     async fn set_nic_mode(&self, mode: NicMode) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_nic_mode");
         self.s.set_nic_mode(mode).await
     }
 
     async fn enable_infinite_boot(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> enable_infinite_boot");
         let attrs: HashMap<String, serde_json::Value> =
             HashMap::from([("BootSeqRetry".to_string(), "Enabled".into())]);
         self.set_bios(attrs).await
     }
 
     async fn is_infinite_boot_enabled(&self) -> Result<Option<bool>, RedfishError> {
-        println!("<kcdPrint> is_infinite_boot_enabled");
         let url = format!("Systems/{}/Bios", self.s.system_id());
         let bios = self.bios().await?;
         let bios_attributes = jsonmap::get_object(&bios, "Attributes", &url)?;
@@ -1098,22 +1001,18 @@ impl Redfish for Bmc {
     }
 
     async fn set_host_rshim(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_host_rshim");
         self.s.set_host_rshim(enabled).await
     }
 
     async fn get_host_rshim(&self) -> Result<Option<EnabledDisabled>, RedfishError> {
-        println!("<kcdPrint> get_host_rshim");
         self.s.get_host_rshim().await
     }
 
     async fn set_idrac_lockdown(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_idrac_lockdown");
         self.set_idrac_lockdown(enabled).await
     }
 
     async fn get_boss_controller(&self) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> get_boss_controller");
         self.get_boss_controller().await
     }
 
@@ -1121,7 +1020,6 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
     ) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> decommission_storage_controller");
         Ok(Some(self.decommission_controller(controller_id).await?))
     }
 
@@ -1130,7 +1028,6 @@ impl Redfish for Bmc {
         controller_id: &str,
         volume_name: &str,
     ) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> create_storage_volume");
         let drives = self.get_storage_drives(controller_id).await?;
 
         let raid_type = match drives.as_array().map(|a| a.len()).unwrap_or(0) {
@@ -1152,7 +1049,6 @@ impl Redfish for Bmc {
     }
 
     async fn is_boot_order_setup(&self, boot_interface_mac: &str) -> Result<bool, RedfishError> {
-        println!("<kcdPrint> is_boot_order_setup");
         let (expected, actual) = self
             .get_expected_and_actual_first_boot_option(boot_interface_mac)
             .await?;
@@ -1160,13 +1056,11 @@ impl Redfish for Bmc {
     }
 
     async fn is_bios_setup(&self, boot_interface_mac: Option<&str>) -> Result<bool, RedfishError> {
-        println!("<kcdPrint> is_bios_setup");
         let diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
         Ok(diffs.is_empty())
     }
 
     async fn get_component_integrities(&self) -> Result<ComponentIntegrities, RedfishError> {
-        println!("<kcdPrint> get_component_integrities");
         self.s.get_component_integrities().await
     }
 
@@ -1174,7 +1068,6 @@ impl Redfish for Bmc {
         &self,
         componnent_integrity_id: &str,
     ) -> Result<crate::model::software_inventory::SoftwareInventory, RedfishError> {
-        println!("<kcdPrint> get_firmware_for_component");
         self.s
             .get_firmware_for_component(componnent_integrity_id)
             .await
@@ -1184,7 +1077,6 @@ impl Redfish for Bmc {
         &self,
         url: &str,
     ) -> Result<crate::model::component_integrity::CaCertificate, RedfishError> {
-        println!("<kcdPrint> get_component_ca_certificate");
         self.s.get_component_ca_certificate(url).await
     }
 
@@ -1193,7 +1085,6 @@ impl Redfish for Bmc {
         url: &str,
         nonce: &str,
     ) -> Result<Task, RedfishError> {
-        println!("<kcdPrint> trigger_evidence_collection");
         self.s.trigger_evidence_collection(url, nonce).await
     }
 
@@ -1201,7 +1092,6 @@ impl Redfish for Bmc {
         &self,
         url: &str,
     ) -> Result<crate::model::component_integrity::Evidence, RedfishError> {
-        println!("<kcdPrint> get_evidence");
         self.s.get_evidence(url).await
     }
 
@@ -1209,12 +1099,10 @@ impl Redfish for Bmc {
         &self,
         level: HostPrivilegeLevel,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_host_privilege_level");
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_utc_timezone");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1228,7 +1116,6 @@ impl Redfish for Bmc {
     }
 
     async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> disable_psu_hot_spare");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1244,7 +1131,6 @@ impl Redfish for Bmc {
 
 impl Bmc {
     pub fn new(s: RedfishStandard) -> Result<Bmc, RedfishError> {
-        println!("<kcdPrint> new");
         Ok(Bmc { s })
     }
 
@@ -1253,7 +1139,6 @@ impl Bmc {
         &self,
         boot_interface_mac: Option<&str>,
     ) -> Result<Vec<MachineSetupDiff>, RedfishError> {
-        println!("<kcdPrint> diff_bios_bmc_attr");
         let mut diffs = vec![];
 
         let bios = self.s.bios_attributes().await?;
@@ -1396,7 +1281,6 @@ impl Bmc {
     }
 
     async fn perform_ac_power_cycle(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> perform_ac_power_cycle");
         self.clear_pending().await?;
 
         // Set PowerCycleRequest in BIOS settings
@@ -1443,7 +1327,6 @@ impl Bmc {
 
     // No changes can be applied if there are pending jobs
     async fn delete_job_queue(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> delete_job_queue");
         // The queue can't be cleared if system lockdown is enabled
         if self.is_lockdown().await? {
             return Err(RedfishError::Lockdown);
@@ -1460,7 +1343,6 @@ impl Bmc {
 
     // is_lockdown checks if system lockdown is enabled.
     async fn is_lockdown(&self) -> Result<bool, RedfishError> {
-        println!("<kcdPrint> is_lockdown");
         let (attrs, url) = self.manager_attributes().await?;
         let system_lockdown = jsonmap::get_str(&attrs, "Lockdown.1.SystemLockdown", &url)?;
 
@@ -1473,7 +1355,6 @@ impl Bmc {
         entry: dell::BootDevices,
         once: bool,
     ) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_boot_first");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset,
         };
@@ -1502,7 +1383,6 @@ impl Bmc {
     }
 
     async fn set_idrac_lockdown(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
-        println!("<kcdPrint> set_idrac_lockdown");
         let manager_id: &str = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1520,7 +1400,6 @@ impl Bmc {
     }
 
     async fn enable_bmc_lockdown(&self, entry: dell::BootDevices) -> Result<(), RedfishError> {
-        println!("<kcdPrint> enable_bmc_lockdown");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset,
         };
@@ -1566,7 +1445,6 @@ impl Bmc {
     }
 
     async fn disable_bios_lockdown(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> disable_bios_lockdown");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -1600,7 +1478,6 @@ impl Bmc {
     }
 
     async fn disable_bmc_lockdown(&self, entry: dell::BootDevices) -> Result<(), RedfishError> {
-        println!("<kcdPrint> disable_bmc_lockdown");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::Immediate, // bmc settings don't require reboot
         };
@@ -1627,7 +1504,6 @@ impl Bmc {
     }
 
     async fn setup_bmc_remote_access(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> setup_bmc_remote_access");
         // Try the regular Attributes path first (iDRAC 9 and earlier)
         match self.setup_bmc_remote_access_standard().await {
             Ok(()) => return Ok(()),
@@ -1646,7 +1522,6 @@ impl Bmc {
 
     /// Setup BMC remote access via standard Attributes path (iDRAC 9 and earlier).
     async fn setup_bmc_remote_access_standard(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> setup_bmc_remote_access_standard");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::Immediate,
         };
@@ -1678,7 +1553,6 @@ impl Bmc {
 
     /// Setup BMC remote access via OEM DellAttributes path (iDRAC 10).
     async fn setup_bmc_remote_access_oem(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> setup_bmc_remote_access_oem");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1696,7 +1570,6 @@ impl Bmc {
     }
 
     async fn bmc_remote_access_status(&self) -> Result<Status, RedfishError> {
-        println!("<kcdPrint> bmc_remote_access_status");
         let (attrs, _) = self.manager_attributes().await?;
         let expected = vec![
             // "any" means any value counts as correctly disabled
@@ -1737,7 +1610,6 @@ impl Bmc {
     }
 
     async fn bios_serial_console_status(&self) -> Result<Status, RedfishError> {
-        println!("<kcdPrint> bios_serial_console_status");
         let mut message = String::new();
 
         // Start with true, then check every value to see whether it means things are not setup
@@ -1863,7 +1735,6 @@ impl Bmc {
 
     // dell stores the sel as part of the manager
     async fn get_system_event_log(&self) -> Result<Vec<LogEntry>, RedfishError> {
-        println!("<kcdPrint> get_system_event_log");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/LogServices/Sel/Entries");
         let (_status_code, log_entry_collection): (_, LogEntryCollection) =
@@ -1877,7 +1748,6 @@ impl Bmc {
     async fn manager_attributes(
         &self,
     ) -> Result<(serde_json::Map<String, serde_json::Value>, String), RedfishError> {
-        println!("<kcdPrint> manager_attributes");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
         let (_status_code, mut body): (_, HashMap<String, serde_json::Value>) =
@@ -1888,7 +1758,6 @@ impl Bmc {
 
     /// Extra Dell-specific attributes we need to set that are not BIOS attributes
     async fn machine_setup_oem(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> machine_setup_oem");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
@@ -1911,7 +1780,6 @@ impl Bmc {
     }
 
     async fn manager_dell_oem_attributes(&self) -> Result<serde_json::Value, RedfishError> {
-        println!("<kcdPrint> manager_dell_oem_attributes");
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
         let (_status_code, mut body): (_, HashMap<String, serde_json::Value>) =
@@ -1926,7 +1794,6 @@ impl Bmc {
     // TPM is enabled by default so we never call this.
     #[allow(dead_code)]
     async fn enable_tpm(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> enable_tpm");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -1950,7 +1817,6 @@ impl Bmc {
     // Lenovo does not support disabling TPM2.0
     #[allow(dead_code)]
     async fn disable_tpm(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> disable_tpm");
         let apply_time = dell::SetSettingsApplyTime {
             apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
         };
@@ -1971,7 +1837,6 @@ impl Bmc {
     }
 
     pub async fn create_bios_config_job(&self) -> Result<String, RedfishError> {
-        println!("<kcdPrint> create_bios_config_job");
         let url = "Managers/iDRAC.Embedded.1/Oem/Dell/Jobs";
 
         let mut arg = HashMap::new();
@@ -1990,7 +1855,6 @@ impl Bmc {
         &self,
         nic_slot: &str,
     ) -> Result<dell::MachineBiosAttrs, RedfishError> {
-        println!("<kcdPrint> machine_setup_attrs");
         let curr_bios_attributes = self.s.bios_attributes().await?;
 
         // RedirAfterBoot: Not available in iDRAC 10
@@ -2060,7 +1924,6 @@ impl Bmc {
         &self,
         current_uefi_password: &str,
     ) -> Result<String, RedfishError> {
-        println!("<kcdPrint> clear_uefi_password_via_import");
         let system_configuration = SystemConfiguration {
             shutdown_type: "Forced".to_string(),
             share_parameters: ShareParameters {
@@ -2079,7 +1942,6 @@ impl Bmc {
         url: &str,
         resp_headers: HeaderMap,
     ) -> Result<String, RedfishError> {
-        println!("<kcdTaskIDs> parse_job_id_from_response_headers url={}", url);
         let key = "location";
         let jid = resp_headers
             .get(key)
@@ -2101,7 +1963,6 @@ impl Bmc {
                 err: InvalidValueError("unable to parse job_id from location string".to_string()),
             })?
             .to_string();
-        println!("<kcdTaskIDs> parse_job_id_from_response_headers parsed job_id={}", jid);
         Ok(jid)
     }
 
@@ -2110,7 +1971,6 @@ impl Bmc {
         &self,
         system_configuration: SystemConfiguration,
     ) -> Result<String, RedfishError> {
-        println!("<kcdPrint> import_system_configuration");
         let url = "Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ImportSystemConfiguration";
         let (_status_code, _resp_body, resp_headers): (
             _,
@@ -2139,7 +1999,6 @@ impl Bmc {
         &self,
         boot_interface_mac_address: &str,
     ) -> Result<NetworkDeviceFunction, RedfishError> {
-        println!("<kcdPrint> get_dpu_nw_device_function");
         let chassis = self.get_chassis(self.s.system_id()).await?;
         let na_id = match chassis.network_adapters {
             Some(id) => id,
@@ -2199,7 +2058,6 @@ impl Bmc {
         &self,
         mac_address: &str,
     ) -> Result<serde_json::Map<String, Value>, RedfishError> {
-        println!("<kcdPrint> get_dell_nic_info");
         let nw_device_function = self.get_dpu_nw_device_function(mac_address).await?;
 
         let oem = nw_device_function
@@ -2230,7 +2088,6 @@ impl Bmc {
 
     // Returns a string like "NIC.Slot.5-1"
     async fn dpu_nic_slot(&self, mac_address: &str) -> Result<String, RedfishError> {
-        println!("<kcdPrint> dpu_nic_slot");
         let dell_nic_info = self.get_dell_nic_info(mac_address).await?;
 
         let nic_slot = dell_nic_info
@@ -2245,7 +2102,6 @@ impl Bmc {
     }
 
     async fn get_boss_controller(&self) -> Result<Option<String>, RedfishError> {
-        println!("<kcdPrint> get_boss_controller");
         let url = "Systems/System.Embedded.1/Storage";
         let (_status_code, storage_collection): (_, StorageCollection) =
             self.s.client.get(url).await?;
@@ -2270,7 +2126,6 @@ impl Bmc {
     }
 
     async fn decommission_controller(&self, controller_id: &str) -> Result<String, RedfishError> {
-        println!("<kcdPrint> decommission_controller");
         // wait for the lifecycle controller status to become Ready before decomissioning the boss controller
         // https://github.com/dell/idrac-Redfish-Scripting/issues/323
         self.lifecycle_controller_is_ready().await?;
@@ -2286,7 +2141,6 @@ impl Bmc {
     }
 
     async fn get_storage_drives(&self, controller_id: &str) -> Result<Value, RedfishError> {
-        println!("<kcdPrint> get_storage_drives");
         let url = format!("Systems/System.Embedded.1/Storage/{controller_id}");
         let (_status_code, body): (_, HashMap<String, serde_json::Value>) =
             self.s.client.get(&url).await?;
@@ -2300,7 +2154,6 @@ impl Bmc {
         raid_type: &str,
         drive_info: Value,
     ) -> Result<String, RedfishError> {
-        println!("<kcdPrint> create_storage_volume");
         if volume_name.len() > 15 || volume_name.is_empty() {
             return Err(RedfishError::GenericError {
                 error: format!(
@@ -2326,7 +2179,6 @@ impl Bmc {
     }
 
     async fn get_lifecycle_controller_status(&self) -> Result<String, RedfishError> {
-        println!("<kcdPrint> get_lifecycle_controller_status");
         let manager_id = self.s.manager_id();
         let url = format!(
             "Managers/{manager_id}/Oem/Dell/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus"
@@ -2351,7 +2203,6 @@ impl Bmc {
     }
 
     async fn lifecycle_controller_is_ready(&self) -> Result<(), RedfishError> {
-        println!("<kcdPrint> lifecycle_controller_is_ready");
         let lc_status = self.get_lifecycle_controller_status().await?;
         if lc_status == "Ready" {
             return Ok(());
@@ -2367,7 +2218,6 @@ impl Bmc {
         &self,
         boot_interface_mac: &str,
     ) -> Result<String, RedfishError> {
-        println!("<kcdPrint> get_expected_dpu_boot_option_name");
         let dell_nic_info = self.get_dell_nic_info(boot_interface_mac).await?;
 
         let device_description = dell_nic_info
@@ -2382,7 +2232,6 @@ impl Bmc {
     }
 
     async fn get_boot_order(&self) -> Result<Vec<BootOption>, RedfishError> {
-        println!("<kcdPrint> get_boot_order");
         let boot_options = self.get_boot_options().await?;
         let mut boot_order: Vec<BootOption> = Vec::new();
         for boot_option in boot_options.members.iter() {
@@ -2401,7 +2250,6 @@ impl Bmc {
         &self,
         boot_interface_mac: &str,
     ) -> Result<(Option<String>, Option<String>), RedfishError> {
-        println!("<kcdPrint> get_expected_and_actual_first_boot_option");
         let expected_first_boot_option = Some(
             self.get_expected_dpu_boot_option_name(boot_interface_mac)
                 .await?,
@@ -2429,7 +2277,6 @@ struct Empty {}
 
 impl UpdateParameters {
     pub fn new(reboot_immediate: bool) -> UpdateParameters {
-        println!("<kcdPrint> UpdateParameters::new");
         let apply_time = match reboot_immediate {
             true => "Immediate",
             false => "OnReset",

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -239,6 +239,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         selected_profile: BiosProfileType,
+        oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.delete_job_queue().await?;
 
@@ -299,7 +303,22 @@ impl Redfish for Bmc {
             }
         };
 
-        self.machine_setup_oem().await?;
+        let oem_attrs = if let Some(dell) = oem_manager_profiles.get(&RedfishVendor::Dell) {
+            let model = crate::model_coerce(
+                self.get_system()
+                    .await?
+                    .model
+                    .unwrap_or_default()
+                    .as_str(),
+            );
+            dell.get(&model)
+                .and_then(|all| all.get(&selected_profile))
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            HashMap::new()
+        };
+        self.machine_setup_oem(&oem_attrs).await?;
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
@@ -1108,18 +1127,6 @@ impl Redfish for Bmc {
         Ok(())
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        let manager_id = self.s.manager_id();
-        let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
-
-        let mut psu_attrs = HashMap::new();
-        psu_attrs.insert("ServerPwr.1.PSRapidOn", "Disabled");
-
-        let body = HashMap::from([("Attributes", psu_attrs)]);
-
-        self.s.client.patch(&url, body).await?;
-        Ok(())
-    }
 }
 
 impl Bmc {
@@ -1750,22 +1757,37 @@ impl Bmc {
     }
 
     /// Extra Dell-specific attributes we need to set that are not BIOS attributes
-    async fn machine_setup_oem(&self) -> Result<(), RedfishError> {
+    async fn machine_setup_oem(
+        &self,
+        extra_attrs: &HashMap<String, serde_json::Value>,
+    ) -> Result<(), RedfishError> {
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
         let current_attrs = self.manager_dell_oem_attributes().await?;
 
-        let mut attributes = HashMap::new();
+        let mut attributes: HashMap<String, serde_json::Value> = HashMap::new();
         // racadm set idrac.webserver.HostHeaderCheck 0
-        attributes.insert("WebServer.1.HostHeaderCheck", "Disabled".to_string());
+        attributes.insert(
+            "WebServer.1.HostHeaderCheck".to_string(),
+            serde_json::json!("Disabled"),
+        );
         // racadm set iDRAC.IPMILan.Enable 1
-        attributes.insert("IPMILan.1.Enable", "Enabled".to_string());
+        attributes.insert(
+            "IPMILan.1.Enable".to_string(),
+            serde_json::json!("Enabled"),
+        );
 
         // Only available in iDRAC 9
         if current_attrs.get("OS-BMC.1.AdminState").is_some() {
-            attributes.insert("OS-BMC.1.AdminState", "Disabled".to_string());
+            attributes.insert(
+                "OS-BMC.1.AdminState".to_string(),
+                serde_json::json!("Disabled"),
+            );
         }
+
+        // Merge config-driven OEM attributes (e.g. PSU Hot Spare settings)
+        attributes.extend(extra_attrs.clone());
 
         let body = HashMap::from([("Attributes", attributes)]);
         self.s.client.patch(&url, body).await?;
@@ -2280,5 +2302,76 @@ impl UpdateParameters {
             apply_time,
             oem: Empty {},
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    // Mirrors the attribute-merge logic in machine_setup_oem so we can test it
+    // without a live HTTP connection.
+    fn build_oem_attributes(
+        extra_attrs: &HashMap<String, serde_json::Value>,
+        has_os_bmc: bool,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut attributes: HashMap<String, serde_json::Value> = HashMap::new();
+        attributes.insert(
+            "WebServer.1.HostHeaderCheck".to_string(),
+            serde_json::json!("Disabled"),
+        );
+        attributes.insert(
+            "IPMILan.1.Enable".to_string(),
+            serde_json::json!("Enabled"),
+        );
+        if has_os_bmc {
+            attributes.insert(
+                "OS-BMC.1.AdminState".to_string(),
+                serde_json::json!("Disabled"),
+            );
+        }
+        attributes.extend(extra_attrs.clone());
+        attributes
+    }
+
+    #[test]
+    fn test_machine_setup_oem_hardcoded_attrs_present() {
+        let extra: HashMap<String, serde_json::Value> = HashMap::new();
+        let attrs = build_oem_attributes(&extra, false);
+        assert_eq!(attrs["WebServer.1.HostHeaderCheck"], serde_json::json!("Disabled"));
+        assert_eq!(attrs["IPMILan.1.Enable"], serde_json::json!("Enabled"));
+        assert!(!attrs.contains_key("OS-BMC.1.AdminState"));
+    }
+
+    #[test]
+    fn test_machine_setup_oem_idrac9_attr_conditionally_added() {
+        let extra: HashMap<String, serde_json::Value> = HashMap::new();
+        let attrs = build_oem_attributes(&extra, true);
+        assert_eq!(attrs["OS-BMC.1.AdminState"], serde_json::json!("Disabled"));
+    }
+
+    #[test]
+    fn test_machine_setup_oem_extra_attrs_merged() {
+        let mut extra: HashMap<String, serde_json::Value> = HashMap::new();
+        extra.insert(
+            "System.1.psuHotSpare".to_string(),
+            serde_json::json!("Disabled"),
+        );
+        let attrs = build_oem_attributes(&extra, false);
+        assert_eq!(attrs["System.1.psuHotSpare"], serde_json::json!("Disabled"));
+        // Hardcoded attrs are still present
+        assert_eq!(attrs["WebServer.1.HostHeaderCheck"], serde_json::json!("Disabled"));
+    }
+
+    #[test]
+    fn test_machine_setup_oem_extra_attrs_override_hardcoded() {
+        // Ensure extra_attrs win over any hardcoded defaults if keys collide.
+        let mut extra: HashMap<String, serde_json::Value> = HashMap::new();
+        extra.insert(
+            "IPMILan.1.Enable".to_string(),
+            serde_json::json!("Disabled"),
+        );
+        let attrs = build_oem_attributes(&extra, false);
+        assert_eq!(attrs["IPMILan.1.Enable"], serde_json::json!("Disabled"));
     }
 }

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -251,12 +251,12 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
         self.set_virt_enable().await?;
         self.set_uefi_nic_boot().await?;
-        self.set_boot_order(BootDevices::Pxe).await
+        self.set_boot_order(BootDevices::Pxe).await.map(|_| None)
     }
 
     async fn machine_setup_status(

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -256,7 +256,8 @@ impl Redfish for Bmc {
         self.clear_tpm().await?;
         self.set_virt_enable().await?;
         self.set_uefi_nic_boot().await?;
-        self.set_boot_order(BootDevices::Pxe).await.map(|_| None)
+        self.set_boot_order(BootDevices::Pxe).await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -251,6 +251,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
@@ -946,9 +950,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -224,6 +224,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
@@ -1010,9 +1014,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -224,7 +224,7 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
         self.boot_first(Boot::Pxe).await?;
@@ -246,7 +246,7 @@ impl Redfish for Bmc {
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,7 @@ pub trait Redfish: Send + Sync + 'static {
         boot_interface_mac: Option<&str>,
         bios_profiles: &BiosProfileVendor,
         selected_profile: BiosProfileType,
+        oem_manager_profiles: &BiosProfileVendor,
     ) -> Result<Option<String>, RedfishError>;
 
     /// Is everything that machine_setup does already done?
@@ -558,21 +559,6 @@ pub trait Redfish: Send + Sync + 'static {
     // Only applicable to Dells
     async fn set_utc_timezone(&self) -> Result<(), RedfishError>;
 
-    /// Disables PSU Hot Spare mode on Dell PowerEdge servers.
-    ///
-    /// This ensures even power distribution across all PSUs instead of
-    /// prioritizing 2 of 4 PSUs in Hot Spare mode.
-    ///
-    /// Specifically sets Dell iDRAC attribute: `ServerPwr.1.PSRapidOn = "Disabled"`
-    ///
-    /// # Returns
-    /// - `Ok(())` if successfully disabled (Dell only)
-    /// - `Err(RedfishError::NotSupported)` for non-Dell vendors
-    /// - `Err(RedfishError)` if the PATCH operation fails
-    ///
-    /// # Note
-    /// Only applicable to Dell servers. Other vendors return `NotSupported`.
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError>;
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,12 +207,14 @@ pub trait Redfish: Send + Sync + 'static {
     /// bios_profiles: Map of vendor/model (with spaces replaced by underscores)/profile/type
     ///   to extra settings; expected to come from config rather than hardcoded.
     /// selected_profile: Profile to use (if present)
+    /// Returns Ok(Some(job_id)) when the vendor creates a job for the BIOS PATCH (e.g. Dell);
+    /// Ok(None) when no job is created. Caller should wait for job completion before configuring boot order.
     async fn machine_setup(
         &self,
         boot_interface_mac: Option<&str>,
         bios_profiles: &BiosProfileVendor,
         selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError>;
+    ) -> Result<Option<String>, RedfishError>;
 
     /// Is everything that machine_setup does already done?
     async fn machine_setup_status(

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -187,6 +187,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         // we don't do any changes for powershelves
         Ok(None)
@@ -717,9 +721,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -187,9 +187,9 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         // we don't do any changes for powershelves
-        Ok(())
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -206,7 +206,8 @@ impl Redfish for Bmc {
         // BF3s that have a BMC that is too old.
         self.set_host_rshim(EnabledDisabled::Disabled).await?;
         self.set_internal_cpu_model(Embedded).await?;
-        self.boot_once(UefiHttp).await.map(|_| None)
+        self.boot_once(UefiHttp).await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -198,7 +198,7 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.set_host_privilege_level(Restricted).await?;
         // we have found that only newer BMC fws support this action.
         // Until we re-enable DPU BMC firmware updates in preingestion,
@@ -206,7 +206,7 @@ impl Redfish for Bmc {
         // BF3s that have a BMC that is too old.
         self.set_host_rshim(EnabledDisabled::Disabled).await?;
         self.set_internal_cpu_model(Embedded).await?;
-        self.boot_once(UefiHttp).await
+        self.boot_once(UefiHttp).await.map(|_| None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -198,6 +198,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.set_host_privilege_level(Restricted).await?;
         // we have found that only newer BMC fws support this action.
@@ -880,9 +884,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -224,8 +224,8 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
-        Ok(())
+    ) -> Result<Option<String>, RedfishError> {
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -224,6 +224,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         Ok(None)
     }
@@ -831,9 +835,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -468,6 +468,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
 
@@ -1110,9 +1114,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -476,7 +476,11 @@ impl Redfish for Bmc {
         attrs.extend(bios_attrs);
         let body = HashMap::from([("Attributes", attrs)]);
         let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
-        self.s.client.patch(&url, body).await.map(|_status_code| None)
+        self.s
+            .client
+            .patch(&url, body)
+            .await
+            .map(|_status_code| None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -468,7 +468,7 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
 
         let bios_attrs = self.machine_setup_attrs().await?;
@@ -476,7 +476,7 @@ impl Redfish for Bmc {
         attrs.extend(bios_attrs);
         let body = HashMap::from([("Attributes", attrs)]);
         let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
-        self.s.client.patch(&url, body).await.map(|_status_code| ())
+        self.s.client.patch(&url, body).await.map(|_status_code| None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -189,6 +189,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
         self.boot_once(UefiHttp).await?;
@@ -792,9 +796,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -189,9 +189,9 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
-        self.boot_once(UefiHttp).await
+        self.boot_once(UefiHttp).await.map(|_| None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -191,7 +191,8 @@ impl Redfish for Bmc {
         _selected_profile: BiosProfileType,
     ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
-        self.boot_once(UefiHttp).await.map(|_| None)
+        self.boot_once(UefiHttp).await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -218,8 +218,8 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
-        self.set_bios_attributes().await
+    ) -> Result<Option<String>, RedfishError> {
+        self.set_bios_attributes().await.map(|_| None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -219,7 +219,8 @@ impl Redfish for Bmc {
         >,
         _selected_profile: BiosProfileType,
     ) -> Result<Option<String>, RedfishError> {
-        self.set_bios_attributes().await.map(|_| None)
+        self.set_bios_attributes().await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -218,6 +218,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.set_bios_attributes().await?;
         Ok(None)
@@ -1013,9 +1017,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -265,7 +265,7 @@ impl Redfish for RedfishStandard {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         Err(RedfishError::NotSupported("machine_setup".to_string()))
     }
 

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -265,6 +265,10 @@ impl Redfish for RedfishStandard {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         Err(RedfishError::NotSupported("machine_setup".to_string()))
     }
@@ -957,12 +961,6 @@ impl Redfish for RedfishStandard {
         Ok(())
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        // PSU Hot Spare is Dell-specific; other vendors handle PSU redundancy differently
-        Err(RedfishError::NotSupported(
-            "disable_psu_hot_spare".to_string(),
-        ))
-    }
 }
 
 impl RedfishStandard {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -196,6 +196,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
 
@@ -942,9 +946,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -196,7 +196,7 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
 
         let bios_attrs = self.machine_setup_attrs().await?;
@@ -204,7 +204,7 @@ impl Redfish for Bmc {
         attrs.extend(bios_attrs);
         let body = HashMap::from([("Attributes", attrs)]);
         let url = format!("Systems/{}/Bios", self.s.system_id());
-        self.s.client.patch(&url, body).await.map(|_status_code| ())
+        self.s.client.patch(&url, body).await.map(|_status_code| None)
     }
 
     async fn machine_setup_status(

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -204,7 +204,11 @@ impl Redfish for Bmc {
         attrs.extend(bios_attrs);
         let body = HashMap::from([("Attributes", attrs)]);
         let url = format!("Systems/{}/Bios", self.s.system_id());
-        self.s.client.patch(&url, body).await.map(|_status_code| None)
+        self.s
+            .client
+            .patch(&url, body)
+            .await
+            .map(|_status_code| None)
     }
 
     async fn machine_setup_status(


### PR DESCRIPTION
***Note: I didn't know I had to add signatures to my commits, and I think this will prevent me from merging this PR once it is approved. After approval I will duplicate the PR with a single signed commit to fix this***

Changes to ensure Dell BIOS configuration jobs complete before configuring boot order. On Dell iDRACs, PATCHing BIOS attributes returns an asynchronous job ID. Previously, we didn't track these jobIDs, which have the potential to lead to boot order configuration racings ahead of pending BIOS changes. Below is a short summary of my changes:

- Track Dell job ID from machine_setup and wait for completion before configuring boot order
- HandleBiosJobFailure recovery (power cycle + BMC reset) with up to 3 retries, mirroring boot order pattern
- Non-Dell vendors: (no job ID → reboot and proceed as before).
- UnlockHost state disables BMC lockdown before BIOS PATCH in the Assigned path.
- test_bios_config_job_happy_path unit test.