### PR TITLE
fix: stop deriving Debug for Endpoint

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -97,7 +97,7 @@ impl RedfishClientPoolBuilder {
 }
 
 /// The endpoint that the redfish client connects to
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)] // WARN: Do not derive Debug: Endpoint may contain credentials and must not be logged accidentally.
 pub struct Endpoint {
     /// Hostname or IP address of BMC
     pub host: String,


### PR DESCRIPTION
Endpoint contains BMC credentials, including password, so deriving Debug makes it easier to accidentally expose secrets in logs or error output.

Remove the Debug derive from Endpoint to avoid accidental credential leakage.