### PR TITLE
fix: add custom deserializer for PSU's power state attribute to handle both string and boolean values.

### DIFF
--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -93,7 +93,8 @@ impl Redfish for Bmc {
     }
 
     async fn get_power_state(&self) -> Result<crate::PowerState, RedfishError> {
-        self.s.get_power_state().await
+        let system = self.get_system().await?;
+        Ok(system.power_state)
     }
 
     async fn get_power_metrics(&self) -> Result<crate::Power, RedfishError> {
@@ -360,7 +361,10 @@ impl Redfish for Bmc {
     }
 
     async fn get_system(&self) -> Result<ComputerSystem, RedfishError> {
-        self.s.get_system().await
+        let mut system = self.s.get_system().await?;
+        let power = self.get_power_metrics().await;
+        system.power_state = power_state_from_psus(&power);
+        Ok(system)
     }
 
     async fn get_secure_boot(&self) -> Result<crate::model::secure_boot::SecureBoot, RedfishError> {
@@ -734,5 +738,33 @@ impl Bmc {
             self.s.client.get(&url).await?;
         let log_entries = log_entry_collection.members;
         Ok(log_entries)
+    }
+}
+
+/// Derives the overall powershelf `PowerState` from individual PSU states.
+/// All On → On, all Off → Off, mixed or no PSUs or fetch failure → Unknown.
+fn power_state_from_psus(power: &Result<Power, RedfishError>) -> crate::PowerState {
+    let supplies = match power {
+        Ok(p) => p.power_supplies.as_deref().unwrap_or_default(),
+        Err(_) => return crate::PowerState::Unknown,
+    };
+
+    if supplies.is_empty() {
+        return crate::PowerState::Unknown;
+    }
+
+    let all_on = supplies
+        .iter()
+        .all(|ps| ps.power_state == Some(crate::PowerState::On));
+    let all_off = supplies
+        .iter()
+        .all(|ps| ps.power_state == Some(crate::PowerState::Off));
+
+    if all_on {
+        crate::PowerState::On
+    } else if all_off {
+        crate::PowerState::Off
+    } else {
+        crate::PowerState::Unknown
     }
 }

--- a/src/model/power.rs
+++ b/src/model/power.rs
@@ -21,11 +21,12 @@
  */
 use super::{LinkType, ODataId, ODataLinks, ResourceStatus, StatusVec};
 use crate::model::sensor::Sensor;
+use crate::model::system::PowerState;
 use serde::{Deserialize, Serialize};
 
 /// Deserializes `PowerState` from either a bool (Lite-On: `true`/`false`)
-/// or a string (GB200: `"On"`/`"Off"`), normalizing to `Option<String>`.
-fn deserialize_power_state<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+/// or a string (GB200: `"On"`/`"Off"`), normalizing to `Option<PowerState>`.
+fn deserialize_power_state<'de, D>(deserializer: D) -> Result<Option<PowerState>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -34,18 +35,20 @@ where
     struct PowerStateVisitor;
 
     impl<'de> de::Visitor<'de> for PowerStateVisitor {
-        type Value = Option<String>;
+        type Value = Option<PowerState>;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("a bool, a string, or null")
+            formatter.write_str("a bool, a PowerState string, or null")
         }
 
         fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
-            Ok(Some(if v { "On" } else { "Off" }.to_string()))
+            Ok(Some(if v { PowerState::On } else { PowerState::Off }))
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            Ok(Some(v.to_string()))
+            serde_json::from_value::<PowerState>(serde_json::Value::String(v.to_string()))
+                .map(Some)
+                .map_err(de::Error::custom)
         }
 
         fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
@@ -178,7 +181,7 @@ pub struct PowerSupply {
     pub power_input_watts: Option<f64>,
     pub power_output_watts: Option<f64>,
     #[serde(default, deserialize_with = "deserialize_power_state")]
-    pub power_state: Option<String>,
+    pub power_state: Option<PowerState>,
     pub power_supply_type: Option<String>,
     pub serial_number: Option<String>,
     pub spare_part_number: Option<String>,

--- a/src/model/power.rs
+++ b/src/model/power.rs
@@ -23,6 +23,50 @@ use super::{LinkType, ODataId, ODataLinks, ResourceStatus, StatusVec};
 use crate::model::sensor::Sensor;
 use serde::{Deserialize, Serialize};
 
+/// Deserializes `PowerState` from either a bool (Lite-On: `true`/`false`)
+/// or a string (GB200: `"On"`/`"Off"`), normalizing to `Option<String>`.
+fn deserialize_power_state<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct PowerStateVisitor;
+
+    impl<'de> de::Visitor<'de> for PowerStateVisitor {
+        type Value = Option<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a bool, a string, or null")
+        }
+
+        fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+            Ok(Some(if v { "On" } else { "Off" }.to_string()))
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(Some(v.to_string()))
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D: serde::Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            deserializer.deserialize_any(PowerStateVisitor)
+        }
+    }
+
+    deserializer.deserialize_any(PowerStateVisitor)
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct OemHpSnmppowerthresholdalert {
@@ -114,6 +158,7 @@ pub struct InputRanges {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct PowerSupply {
+    pub id: Option<String>,
     pub firmware_version: Option<String>,
     // we need to track this metric
     pub last_power_output_watts: Option<f64>, // not in Supermicro or NVIDIA DPU
@@ -132,7 +177,7 @@ pub struct PowerSupply {
     pub power_capacity_watts: Option<f64>, // present but 'null' on Supermicro
     pub power_input_watts: Option<f64>,
     pub power_output_watts: Option<f64>,
-    #[serde(skip)] // gb200 has this as string and liteon has it as bool
+    #[serde(default, deserialize_with = "deserialize_power_state")]
     pub power_state: Option<String>,
     pub power_supply_type: Option<String>,
     pub serial_number: Option<String>,

--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -78,6 +78,7 @@ pub enum PowerState {
     PoweringOn,
     Paused,
     Reset,
+    Unknown,
 }
 
 impl fmt::Display for PowerState {


### PR DESCRIPTION
GB200s report the PSU power state as a string: "On"/"Off"
Liteon PMCs report the PSU power state as a boolean: true/false

Querying a powershelf before the changes:
```
spyda@control72-cno1-cp1-jhb01:~$ ./carbide-admin-cli redfish --address 7.243.170.140 --username root --password 'password' --vendor lite-on-power-shelf get-power-state

Off
```

Querying a powershelf after the changes:
```
spyda@control72-cno1-cp1-jhb01:~$ ./carbide-admin-cli redfish --address 7.243.170.140 --username root --password 'password' --vendor lite-on-power-shelf get-power-state

On
```
