### PR TITLE
fix: add 'Sleep' as an additional ResourceState enum

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -402,6 +402,8 @@ pub enum ResourceState {
     Updating,
     Qualified,
     Unknown,
+    // Lite-On powershelf PSUs report "Sleep" when powered off
+    Sleep,
 }
 
 impl fmt::Display for ResourceState {


### PR DESCRIPTION
fix: add 'Sleep' as an additional ResourceState enum as Liteon PSUs report that value when the powershelf is turned off

Testing on a powershelf turned off:

Before change:
```
root@carbide-api-5f546f649-xj4ps:/opt/carbide# ./carbide-admin-cli redfish get-power-state --address 7.243.146.242 --username root --password 0penBmc
Unknown
root@carbide-api-5f546f649-xj4ps:/opt/carbide# 
root@carbide-api-5f546f649-xj4ps:/opt/carbide# ./carbide-admin-cli redfish power-metrics --address 7.243.146.242 --username root --password 0penBmc
Error: 
   0: Could not deserialize response from https://7.243.146.242/redfish/v1/Chassis/powershelf/PowerSubsystem/PowerSupplies/0. Body: {
        "@odata.id": "/redfish/v1/Chassis/powershelf/PowerSubsystem/PowerSupplies/0",
        "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
        "CapacityWatts": "5500",
        "FirmwareVersion": "0x6 / 0x8",
        "HardwareVersion": "X7",
        "HotPluggable": true,
        "Id": "0",
        "InputSourceNum": 1,
        "Location": {
          "LocationOrdinalValue": 0,
          "LocationType": "Bay",
          "ServiceLabel": "PSU 0"
        },
        "Manufacturer": "LITE-ON TECHNOLOGY CORP.",
        "Model": "SP-2552-1R",
        "Name": "Power Supply 0",
        "PowerState": false,
        "Sensors": [
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/voltage_p0_vout"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/current_p0_iout"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/power_p0_pout"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/power_p0_pin"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/voltage_p0_vin"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/current_p0_iin"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/temperature_p0_ambient"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/temperature_p0_hotspot"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/temperature_p0_exhaust"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/fantach_p0_fan1"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/powershelf/Sensors/frequency_p0_freqin"
          }
        ],
        "SerialNumber": "6PL1R01X7511ACJ",
        "Status": {
          "Health": "OK",
          "State": "Sleep"
        }
      }. unknown variant `Sleep`, expected one of `Enabled`, `Disabled`, `Degraded`, `Standby`, `StandbyOffline`, `StandbySpare`, `InTest`, `Starting`, `Absent`, `UnavailableOffline`, `Deferring`, `Quiesced`, `Updating`, `Qualified`, `Unknown` at line 57 column 20
   1: unknown variant `Sleep`, expected one of `Enabled`, `Disabled`, `Degraded`, `Standby`, `StandbyOffline`, `StandbySpare`, `InTest`, `Starting`, `Absent`, `UnavailableOffline`, `Deferring`, `Quiesced`, `Updating`, `Qualified`, `Unknown` at line 57 column 20

Location:
   crates/admin-cli/src/redfish/cmds.rs:274

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.

```

After change:
```
root@control72-cno1-cp1-jhb01:/tmp# ./carbide-admin-cli redfish power-metrics --address 7.243.146.242 --username root --password 0penBmc
Power { odata: None, id: "Power", name: "Power", power_control: [], power_supplies: Some([PowerSupply { id: Some("0"), firmware_version: Some("0x6 / 0x8"), last_power_output_watts: None, line_input_voltage: None, line_input_voltage_type: None, efficiency_percent: None, hardware_version: Some("X7"), hot_pluggable: Some(true), manufacturer: Some("LITE-ON TECHNOLOGY CORP."), model: Some("SP-2552-1R"), name: "Power Supply 0", input_ranges: None, power_output_amps: None, capacity_watts: Some("5500"), power_capacity_watts: None, power_input_watts: None, power_output_watts: None, power_state: Some(Off), power_supply_type: None, serial_number: Some("6PL1R01X7511ACJ"), spare_part_number: None, part_number: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Sleep) } }, PowerSupply { id: Some("1"), firmware_version: Some("0x6 / 0x8"), last_power_output_watts: None, line_input_voltage: None, line_input_voltage_type: None, efficiency_percent: None, hardware_version: Some("X7"), hot_pluggable: Some(true), manufacturer: Some("LITE-ON TECHNOLOGY CORP."), model: Some("SP-2552-1R"), name: "Power Supply 1", input_ranges: None, power_output_amps: None, capacity_watts: Some("5500"), power_capacity_watts: None, power_input_watts: None, power_output_watts: None, power_state: Some(Off), power_supply_type: None, serial_number: Some("6PL1R01X75119AN"), spare_part_number: None, part_number: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Sleep) } }, PowerSupply { id: Some("2"), firmware_version: Some("0x6 / 0x8"), last_power_output_watts: None, line_input_voltage: None, line_input_voltage_type: None, efficiency_percent: None, hardware_version: Some("X7"), hot_pluggable: Some(true), manufacturer: Some("LITE-ON TECHNOLOGY CORP."), model: Some("SP-2552-1R"), name: "Power Supply 2", input_ranges: None, power_output_amps: None, capacity_watts: Some("5500"), power_capacity_watts: None, power_input_watts: None, power_output_watts: None, power_state: Some(Off), power_supply_type: None, serial_number: Some("6PL1R01X75119UH"), spare_part_number: None, part_number: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Sleep) } }, PowerSupply { id: Some("3"), firmware_version: Some("0x6 / 0x8"), last_power_output_watts: None, line_input_voltage: None, line_input_voltage_type: None, efficiency_percent: None, hardware_version: Some("X7"), hot_pluggable: Some(true), manufacturer: Some("LITE-ON TECHNOLOGY CORP."), model: Some("SP-2552-1R"), name: "Power Supply 3", input_ranges: None, power_output_amps: None, capacity_watts: Some("5500"), power_capacity_watts: None, power_input_watts: None, power_output_watts: None, power_state: Some(Off), power_supply_type: None, serial_number: Some("6PL1R01X75119CL"), spare_part_number: None, part_number: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Sleep) } }, PowerSupply { id: Some("4"), firmware_version: Some("0x6 / 0x8"), last_power_output_watts: None, line_input_voltage: None, line_input_voltage_type: None, efficiency_percent: None, hardware_version: Some("X7"), hot_pluggable: Some(true), manufacturer: Some("LITE-ON TECHNOLOGY CORP."), model: Some("SP-2552-1R"), name: "Power Supply 4", input_ranges: None, power_output_amps: None, capacity_watts: Some("5500"), power_capacity_watts: None, power_input_watts: None, power_output_watts: None, power_state: Some(Off), power_supply_type: None, serial_number: Some("6PL1R01X7511A5Q"), spare_part_number: None, part_number: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Sleep) } }, PowerSupply { id: Some("5"), firmware_version: Some("0x6 / 0x8"), last_power_output_watts: None, line_input_voltage: None, line_input_voltage_type: None, efficiency_percent: None, hardware_version: Some("X7"), hot_pluggable: Some(true), manufacturer: Some("LITE-ON TECHNOLOGY CORP."), model: Some("SP-2552-1R"), name: "Power Supply 5", input_ranges: None, power_output_amps: None, capacity_watts: Some("5500"), power_capacity_watts: None, power_input_watts: None, power_output_watts: None, power_state: Some(Off), power_supply_type: None, serial_number: Some("6PL1R01X75116RY"), spare_part_number: None, part_number: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Sleep) } }]), voltages: Some([Voltages { name: "chassis input voltage", physical_context: None, reading_volts: Some(238.91), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "chassis output voltage", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p0 vin", physical_context: None, reading_volts: Some(240.25), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p0 vout", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p1 vin", physical_context: None, reading_volts: Some(238.25), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p1 vout", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p2 vin", physical_context: None, reading_volts: Some(238.75), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p2 vout", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p3 vin", physical_context: None, reading_volts: Some(238.75), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p3 vout", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p4 vin", physical_context: None, reading_volts: Some(238.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p4 vout", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p5 vin", physical_context: None, reading_volts: Some(239.75), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }, Voltages { name: "p5 vout", physical_context: None, reading_volts: Some(0.0), lower_threshold_critical: None, upper_threshold_critical: None, status: ResourceStatus { health: Some(Ok), health_rollup: None, state: Some(Enabled) } }]), redundancy: None }
root@control72-cno1-cp1-jhb01:/tmp# ./carbide-admin-cli redfish get-power-state --address 7.243.146.242 --username root --password 0penBmc
Off
```