### PR TITLE
fix: do not try to anonymously query the chassis subsystem as part of querying the service root

### DIFF
--- a/src/standard.rs
+++ b/src/standard.rs
@@ -632,17 +632,7 @@ impl Redfish for RedfishStandard {
     }
 
     async fn get_service_root(&self) -> Result<ServiceRoot, RedfishError> {
-        let (_status_code, mut body): (StatusCode, ServiceRoot) = self.client.get("").await?;
-        // fix lite-on power shelf bmc behavior
-        if body.vendor.is_none() {
-            let chassis_all = self.get_chassis_all().await?;
-            if chassis_all.contains(&"powershelf".to_string()) {
-                let chassis = self.get_chassis("powershelf").await?;
-                if let Some(x) = chassis.manufacturer {
-                    body.vendor = Some(x);
-                }
-            }
-        }
+        let (_status_code, body) = self.client.get("").await?;
         Ok(body)
     }
 


### PR DESCRIPTION
We have logic to special case powershelf handling in site explorer: we query the chassis using the credentials in expected powershelves.

Reverts changes introduced in this commit:
https://github.com/NVIDIA/libredfish/commit/b040d6dfa7e8cbe0250aafc6ed442163f4113bea

```
spyda@control72-cno1-cp1-jhb01:~$ curl -k  https://7.243.146.248/redfish/v1
{
  "@odata.id": "/redfish/v1",
  "@odata.type": "#ServiceRoot.v1_11_0.ServiceRoot",
  "AccountService": {
    "@odata.id": "/redfish/v1/AccountService"
  },
  "CertificateService": {
    "@odata.id": "/redfish/v1/CertificateService"
  },
  "Chassis": {
    "@odata.id": "/redfish/v1/Chassis"
  },
  "EventService": {
    "@odata.id": "/redfish/v1/EventService"
  },
  "Id": "RootService",
  "JsonSchemas": {
    "@odata.id": "/redfish/v1/JsonSchemas"
  },
  "Links": {
    "Sessions": {
      "@odata.id": "/redfish/v1/SessionService/Sessions"
    }
  },
  "Managers": {
    "@odata.id": "/redfish/v1/Managers"
  },
  "Name": "Root Service",
  "ProtocolFeaturesSupported": {
    "DeepOperations": {
      "DeepPATCH": false,
      "DeepPOST": false
    },
    "ExcerptQuery": false,
    "ExpandQuery": {
      "ExpandAll": false,
      "Levels": false,
      "Links": false,
      "NoLinks": false
    },
    "FilterQuery": false,
    "OnlyMemberQuery": false,
    "SelectQuery": false
  },
  "RedfishVersion": "1.9.0",
  "Registries": {
    "@odata.id": "/redfish/v1/Registries"
  },
  "SessionService": {
    "@odata.id": "/redfish/v1/SessionService"
  },
  "Tasks": {
    "@odata.id": "/redfish/v1/TaskService"
  },
  "TelemetryService": {
    "@odata.id": "/redfish/v1/TelemetryService"
  },
  "UUID": "3a9bae74-e8e2-4ba7-87fe-b1f13c32b37c",
  "UpdateService": {
    "@odata.id": "/redfish/v1/UpdateService"
  }
}
spyda@control72-cno1-cp1-jhb01:~$ curl -k  https://7.243.146.248/redfish/v1/Chassis
Unauthorized
```