### PR TITLE
fix: update Manager struct to match the redfish spec

### DIFF
--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -1232,7 +1232,10 @@ impl Bmc {
         let ilo_manager = self.get_manager().await;
         match ilo_manager {
             Ok(manager) => {
-                let fw_parts: Vec<&str> = manager.firmware_version.split_whitespace().collect();
+                let Some(fw_version) = manager.firmware_version else {
+                    return false;
+                };
+                let fw_parts: Vec<&str> = fw_version.split_whitespace().collect();
                 let fw_major: i32 = fw_parts[1].parse().unwrap_or_default();
                 let fw_minor: f32 = fw_parts[2][1..].parse().unwrap_or(0.0);
                 fw_major >= 6 && fw_minor >= 1.40

--- a/src/model/manager.rs
+++ b/src/model/manager.rs
@@ -42,22 +42,22 @@ pub struct Managers {
 pub struct Manager {
     #[serde(flatten)]
     pub odata: ODataLinks,
-    pub actions: Action,
+    pub actions: Option<Action>,
     pub command_shell: Option<Commandshell>,
     pub date_time: Option<DateTime<Utc>>,
     pub description: Option<String>,
-    pub ethernet_interfaces: ODataId,
-    pub firmware_version: String,
+    pub ethernet_interfaces: Option<ODataId>,
+    pub firmware_version: Option<String>,
     pub graphical_console: Option<Commandshell>,
     pub id: String,
-    pub log_services: ODataId,
-    pub manager_type: String,
+    pub log_services: Option<ODataId>,
+    pub manager_type: Option<String>,
     pub model: Option<String>,
     pub name: String,
-    pub network_protocol: ODataId,
-    pub status: Status,
+    pub network_protocol: Option<ODataId>,
+    pub status: Option<Status>,
     #[serde(rename = "UUID")]
-    pub uuid: String,
+    pub uuid: Option<String>,
     pub oem: Option<ManagerExtensions>,
 }
 


### PR DESCRIPTION
fix: update Manager struct to match the redfish spec whre only four fields are required: @odata.id, @odata.type, Id, and Name

https://redfish.dmtf.org/schemas/v1/Manager.v1_24_0.yaml
