### PR TITLE
feat: add set_boot_override trait method with HttpBootUri support

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -27,7 +27,10 @@ use crate::{
     jsonmap,
     model::{
         account_service::ManagerAccount,
-        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{
+            BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
+            BootSourceOverrideTarget,
+        },
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -586,8 +589,17 @@ impl Redfish for Bmc {
                 Boot::HardDisk => BootSourceOverrideTarget::Hdd,
                 Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
             };
-            self.set_boot_override(override_target, BootSourceOverrideEnabled::Once)
-                .await
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
         })
     }
 
@@ -602,6 +614,39 @@ impl Redfish for Bmc {
                 Boot::UefiHttp => "UefiHttp",
             };
             self.set_boot_order(alias).await
+        })
+    }
+
+    /// AMI requires patching `/Systems/{id}` (NOT `/SD`) with an `If-Match` header.
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            // AMI BMCs default to UEFI mode when the caller doesn't specify one.
+            let mode = settings.mode.unwrap_or(BootSourceOverrideMode::UEFI);
+            boot_data.insert(
+                "BootSourceOverrideMode".to_string(),
+                mode.to_string().into(),
+            );
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}", self.s.system_id());
+            self.s
+                .client
+                .patch_with_if_match(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
         })
     }
 
@@ -1124,28 +1169,6 @@ impl Redfish for Bmc {
 }
 
 impl Bmc {
-    /// AMI requires patching to /Systems/{id} (NOT /SD) with If-Match header
-    async fn set_boot_override(
-        &self,
-        override_target: BootSourceOverrideTarget,
-        override_enabled: BootSourceOverrideEnabled,
-    ) -> Result<(), RedfishError> {
-        let boot_data = HashMap::from([
-            ("BootSourceOverrideMode".to_string(), "UEFI".to_string()),
-            (
-                "BootSourceOverrideEnabled".to_string(),
-                override_enabled.to_string(),
-            ),
-            (
-                "BootSourceOverrideTarget".to_string(),
-                override_target.to_string(),
-            ),
-        ]);
-        let data = HashMap::from([("Boot", boot_data)]);
-        let url = format!("Systems/{}", self.s.system_id());
-        self.s.client.patch_with_if_match(&url, data).await
-    }
-
     async fn get_system_and_boot_options(
         &self,
     ) -> Result<(ComputerSystem, Vec<BootOption>), RedfishError> {

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -31,6 +31,7 @@ use crate::{
     jsonmap,
     model::{
         account_service::ManagerAccount,
+        boot::BootOverride,
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -600,6 +601,21 @@ impl Redfish for Bmc {
                     "No Dell UefiHttp implementation".to_string(),
                 )),
             }
+        })
+    }
+
+    /// Not yet implemented on Dell iDRAC. Dell does not expose the standard
+    /// Redfish `Boot.HttpBootUri` property; setting an HTTP boot URI on Dell
+    /// requires PATCHing the `HttpDev1Uri` and related BIOS attributes via
+    /// `/Systems/{id}/Bios/Settings`. Planned as a follow-up PR.
+    fn set_boot_override<'a>(
+        &'a self,
+        _settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(
+                "No Dell set_boot_override implementation".to_string(),
+            ))
         })
     }
 

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -27,6 +27,7 @@ use serde_json::Value;
 use crate::{
     model::{
         account_service::ManagerAccount,
+        boot::{BootOverride, BootSourceOverrideMode},
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -473,6 +474,38 @@ impl Redfish for Bmc {
 
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.boot_first(target).await })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            // HPE iLO defaults to UEFI mode when the caller doesn't specify one.
+            let mode = settings.mode.unwrap_or(BootSourceOverrideMode::UEFI);
+            boot_data.insert(
+                "BootSourceOverrideMode".to_string(),
+                mode.to_string().into(),
+            );
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
+        })
     }
 
     fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -34,6 +34,7 @@ use tokio::time::sleep;
 use tracing::debug;
 
 use crate::model::account_service::ManagerAccount;
+use crate::model::boot::BootOverride;
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
 use crate::model::oem::lenovo::{BootSettings, FrontPanelUSB, LenovoBootOrder};
@@ -583,6 +584,21 @@ impl Redfish for Bmc {
                     "No Lenovo UefiHttp implementation".to_string(),
                 )),
             }
+        })
+    }
+
+    /// Not yet implemented on Lenovo XCC. Like Dell, Lenovo does not expose
+    /// the standard Redfish `Boot.HttpBootUri` property; setting an HTTP boot
+    /// URI on Lenovo requires a vendor-specific BIOS attribute path. Planned
+    /// as a follow-up PR.
+    fn set_boot_override<'a>(
+        &'a self,
+        _settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(
+                "No Lenovo set_boot_override implementation".to_string(),
+            ))
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ use std::{collections::HashMap, fmt, future::Future, path::Path, pin::Pin, time:
 
 pub mod model;
 use model::account_service::ManagerAccount;
+pub use model::boot::{
+    BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode, BootSourceOverrideTarget,
+};
 pub use model::chassis::{Assembly, Chassis, NetworkAdapter};
 pub use model::ethernet_interface::EthernetInterface;
 pub use model::network_device_function::NetworkDeviceFunction;
@@ -283,6 +286,27 @@ pub trait Redfish: Send + Sync + 'static {
 
     /// Change boot order putting this target first
     fn boot_first<'a>(&'a self, target: Boot) -> RedfishFuture<'a, Result<(), RedfishError>>;
+
+    /// Set a boot source override, optionally including an HTTP boot URI.
+    ///
+    /// This is a lower-level alternative to [`Redfish::boot_once`] /
+    /// [`Redfish::boot_first`] that exposes the full Redfish `Boot` override
+    /// shape: `target`, `enabled` (`Once`/`Continuous`/`Disabled`), `mode`
+    /// (`UEFI`/`Legacy`), and `http_boot_uri`.
+    ///
+    /// When `target` is `UefiHttp` and `http_boot_uri` is `Some`, the BMC pins
+    /// the boot URL — the host will UEFI-HTTP-boot from that URI on the next
+    /// applicable boot without needing DHCP option 67. If `http_boot_uri` is
+    /// `None`, the firmware falls back to DHCP option 67 per the UEFI HTTP
+    /// Boot specification.
+    ///
+    /// Returns an optional job ID. Vendors that route the change through a
+    /// BIOS settings job schedule it to apply on next reboot and return the
+    /// job ID. Vendors that apply the change immediately return `None`.
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
 
     /// Change boot order by setting boot array.
     fn change_boot_order<'a>(

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs::File;
 
 use crate::model::account_service::ManagerAccount;
+use crate::model::boot::BootOverride;
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
 use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
@@ -338,6 +339,17 @@ impl Redfish for Bmc {
         Box::pin(async move {
             Err(RedfishError::NotSupported(
                 "Lite-on powershelf does not support changing boot order".to_string(),
+            ))
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        _settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(
+                "Lite-on powershelf does not support boot source overrides".to_string(),
             ))
         })
     }

--- a/src/model/boot.rs
+++ b/src/model/boot.rs
@@ -113,6 +113,27 @@ pub enum BootSourceOverrideMode {
     InvalidValue,
 }
 
+impl fmt::Display for BootSourceOverrideMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Settings for a Redfish boot source override, applied via
+/// [`Redfish::set_boot_override`](crate::Redfish::set_boot_override).
+///
+/// `target` and `enabled` are required. `mode` is typically `UEFI` for modern
+/// systems and can be left `None` to keep the current mode unchanged. `http_boot_uri`
+/// only applies when `target` is `UefiHttp`; if `None`, the firmware obtains the
+/// boot URL from DHCP option 67 as specified by the UEFI HTTP Boot specification.
+#[derive(Debug, Clone)]
+pub struct BootOverride {
+    pub target: BootSourceOverrideTarget,
+    pub enabled: BootSourceOverrideEnabled,
+    pub mode: Option<BootSourceOverrideMode>,
+    pub http_boot_uri: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum TrustedModuleRequiredToBoot {
     Disabled,

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -40,7 +40,10 @@ use crate::HostPrivilegeLevel::Restricted;
 use crate::InternalCPUModel::Embedded;
 use crate::{
     model::{
-        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{
+            BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
+            BootSourceOverrideTarget,
+        },
         chassis::{Assembly, NetworkAdapter},
         oem::nvidia_dpu::{HostPrivilegeLevel, InternalCPUModel},
         sel::{LogEntry, LogEntryCollection},
@@ -375,29 +378,22 @@ impl Redfish for Bmc {
         target: crate::Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            match target {
-                crate::Boot::Pxe => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Pxe,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::HardDisk => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Hdd,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::UefiHttp => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::UefiHttp,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-            }
+            let override_target = match target {
+                crate::Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                crate::Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                crate::Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+            };
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
         })
     }
 
@@ -411,6 +407,38 @@ impl Redfish for Bmc {
                 crate::Boot::HardDisk => self.set_boot_order(&BootOptionName::Disk).await,
                 crate::Boot::UefiHttp => self.set_boot_order(&BootOptionName::Http).await,
             }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            // BlueField DPU BMCs default to UEFI mode when the caller doesn't specify one.
+            let mode = settings.mode.unwrap_or(BootSourceOverrideMode::UEFI);
+            boot_data.insert(
+                "BootSourceOverrideMode".to_string(),
+                mode.to_string().into(),
+            );
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}/Settings", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
         })
     }
 
@@ -1117,29 +1145,6 @@ impl Bmc {
         self.patch_bios_setting(data)
             .await
             .map(|_status_code| Ok(()))?
-    }
-
-    async fn set_boot_override(
-        &self,
-        override_target: BootSourceOverrideTarget,
-        override_enabled: BootSourceOverrideEnabled,
-    ) -> Result<(), RedfishError> {
-        let mut data: HashMap<String, String> = HashMap::new();
-        data.insert("BootSourceOverrideMode".to_string(), "UEFI".to_string());
-        data.insert(
-            "BootSourceOverrideEnabled".to_string(),
-            format!("{}", override_enabled),
-        );
-        data.insert(
-            "BootSourceOverrideTarget".to_string(),
-            format!("{}", override_target),
-        );
-        let url = format!("Systems/{}/Settings ", self.s.system_id());
-        self.s
-            .client
-            .patch(&url, HashMap::from([("Boot", data)]))
-            .await?;
-        Ok(())
     }
 
     // name: The name of the device you want to make the first boot choice.

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -14,7 +14,7 @@ use crate::model::PCIeDevices;
 use crate::REDFISH_ENDPOINT;
 use crate::{
     model::{
-        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
         sel::{LogEntry, LogEntryCollection},
         service_root::ServiceRoot,
@@ -352,30 +352,23 @@ impl Redfish for Bmc {
         target: crate::Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            match target {
-                crate::Boot::Pxe => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Pxe,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::HardDisk => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Hdd,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::UefiHttp => {
-                    // : UefiHttp isn't in the GH200's list of AllowableValues, but it seems to work
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::UefiHttp,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-            }
+            // UefiHttp isn't in the GH200's list of AllowableValues, but it seems to work.
+            let override_target = match target {
+                crate::Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                crate::Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                crate::Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+            };
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
         })
     }
 
@@ -400,6 +393,38 @@ impl Redfish for Bmc {
                 }
                 crate::Boot::UefiHttp => self.set_boot_order(BootOptionName::Http).await,
             }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            if let Some(mode) = settings.mode {
+                boot_data.insert(
+                    "BootSourceOverrideMode".to_string(),
+                    mode.to_string().into(),
+                );
+            }
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}/Settings", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
         })
     }
 
@@ -1053,28 +1078,6 @@ impl Redfish for Bmc {
 }
 
 impl Bmc {
-    async fn set_boot_override(
-        &self,
-        override_target: BootSourceOverrideTarget,
-        override_enabled: BootSourceOverrideEnabled,
-    ) -> Result<(), RedfishError> {
-        let mut data: HashMap<String, String> = HashMap::new();
-        data.insert(
-            "BootSourceOverrideEnabled".to_string(),
-            format!("{}", override_enabled),
-        );
-        data.insert(
-            "BootSourceOverrideTarget".to_string(),
-            format!("{}", override_target),
-        );
-        let url = format!("Systems/{}/Settings ", self.s.system_id());
-        self.s
-            .client
-            .patch(&url, HashMap::from([("Boot", data)]))
-            .await?;
-        Ok(())
-    }
-
     // name: The name of the device you want to make the first boot choice.
     async fn set_boot_order(&self, name: BootOptionName) -> Result<(), RedfishError> {
         let boot_array = self

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -42,7 +42,7 @@ use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateSe
 use crate::{
     jsonmap,
     model::{
-        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
         power::{Power, PowerSupply, Voltages},
         sel::{LogEntry, LogEntryCollection},
@@ -638,29 +638,22 @@ impl Redfish for Bmc {
         target: crate::Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            match target {
-                crate::Boot::Pxe => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Pxe,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::HardDisk => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Hdd,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::UefiHttp => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::UefiHttp,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-            }
+            let override_target = match target {
+                crate::Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                crate::Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                crate::Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+            };
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
         })
     }
 
@@ -686,6 +679,38 @@ impl Redfish for Bmc {
                 }
                 crate::Boot::UefiHttp => self.set_boot_order(BootOptionName::Http).await,
             }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            if let Some(mode) = settings.mode {
+                boot_data.insert(
+                    "BootSourceOverrideMode".to_string(),
+                    mode.to_string().into(),
+                );
+            }
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}/Settings", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
         })
     }
 
@@ -1375,28 +1400,6 @@ impl Bmc {
         }
 
         Ok((expected_first_boot_option, actual_first_boot_option))
-    }
-
-    async fn set_boot_override(
-        &self,
-        override_target: BootSourceOverrideTarget,
-        override_enabled: BootSourceOverrideEnabled,
-    ) -> Result<(), RedfishError> {
-        let mut data: HashMap<String, String> = HashMap::new();
-        data.insert(
-            "BootSourceOverrideEnabled".to_string(),
-            format!("{}", override_enabled),
-        );
-        data.insert(
-            "BootSourceOverrideTarget".to_string(),
-            format!("{}", override_target),
-        );
-        let url = format!("Systems/{}/Settings ", self.s.system_id());
-        self.s
-            .client
-            .patch(&url, HashMap::from([("Boot", data)]))
-            .await?;
-        Ok(())
     }
 
     // name: The name of the device you want to make the first boot choice.

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -13,7 +13,7 @@ use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateSe
 use crate::Boot::UefiHttp;
 use crate::{
     model::{
-        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
         sel::{LogEntry, LogEntryCollection},
         service_root::ServiceRoot,
@@ -331,30 +331,23 @@ impl Redfish for Bmc {
         target: crate::Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            match target {
-                crate::Boot::Pxe => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Pxe,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::HardDisk => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Hdd,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                crate::Boot::UefiHttp => {
-                    // : UefiHttp isn't in the GH200's list of AllowableValues, but it seems to work
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::UefiHttp,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-            }
+            // UefiHttp isn't in the GH200's list of AllowableValues, but it seems to work.
+            let override_target = match target {
+                crate::Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                crate::Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                crate::Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+            };
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
         })
     }
 
@@ -379,6 +372,38 @@ impl Redfish for Bmc {
                 }
                 crate::Boot::UefiHttp => self.set_boot_order(BootOptionName::Http).await,
             }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            if let Some(mode) = settings.mode {
+                boot_data.insert(
+                    "BootSourceOverrideMode".to_string(),
+                    mode.to_string().into(),
+                );
+            }
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}/Settings", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
         })
     }
 
@@ -1001,28 +1026,6 @@ impl Redfish for Bmc {
 }
 
 impl Bmc {
-    async fn set_boot_override(
-        &self,
-        override_target: BootSourceOverrideTarget,
-        override_enabled: BootSourceOverrideEnabled,
-    ) -> Result<(), RedfishError> {
-        let mut data: HashMap<String, String> = HashMap::new();
-        data.insert(
-            "BootSourceOverrideEnabled".to_string(),
-            format!("{}", override_enabled),
-        );
-        data.insert(
-            "BootSourceOverrideTarget".to_string(),
-            format!("{}", override_target),
-        );
-        let url = format!("Systems/{}/Settings ", self.s.system_id());
-        self.s
-            .client
-            .patch(&url, HashMap::from([("Boot", data)]))
-            .await?;
-        Ok(())
-    }
-
     // name: The name of the device you want to make the first boot choice.
     async fn set_boot_order(&self, name: BootOptionName) -> Result<(), RedfishError> {
         let boot_array = self

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -33,7 +33,10 @@ use version_compare::Version;
 use crate::{
     model::{
         account_service::ManagerAccount,
-        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{
+            BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
+            BootSourceOverrideTarget,
+        },
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -426,29 +429,22 @@ impl Redfish for Bmc {
 
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            match target {
-                Boot::Pxe => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Pxe,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                Boot::HardDisk => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::Hdd,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-                Boot::UefiHttp => {
-                    self.set_boot_override(
-                        BootSourceOverrideTarget::UefiHttp,
-                        BootSourceOverrideEnabled::Once,
-                    )
-                    .await
-                }
-            }
+            let override_target = match target {
+                Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+            };
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
         })
     }
 
@@ -462,6 +458,71 @@ impl Redfish for Bmc {
                 Boot::HardDisk => self.set_boot_order(BootDevices::Hdd).await,
                 Boot::UefiHttp => self.set_boot_order(BootDevices::UefiHttp).await,
             }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            // Viking BMCs default to UEFI mode when the caller doesn't specify one.
+            let mode = settings.mode.unwrap_or(BootSourceOverrideMode::UEFI);
+            boot_data.insert(
+                "BootSourceOverrideMode".to_string(),
+                mode.to_string().into(),
+            );
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let data = HashMap::from([("Boot", boot_data)]);
+            // Viking BMCs use a pending-settings `SD` endpoint that requires an If-Match
+            // ETag from a prior GET to succeed.
+            let url = format!("Systems/{}/SD", self.s.system_id());
+            let (_, body): (_, HashMap<String, serde_json::Value>) =
+                self.s.client.get(&url).await?;
+            let key = "@odata.etag";
+            let etag = body
+                .get(key)
+                .ok_or_else(|| RedfishError::MissingKey {
+                    key: key.to_string(),
+                    url: url.to_string(),
+                })?
+                .as_str()
+                .ok_or_else(|| RedfishError::InvalidKeyType {
+                    key: key.to_string(),
+                    expected_type: "Object".to_string(),
+                    url: url.to_string(),
+                })?;
+
+            let headers: Vec<(HeaderName, String)> = vec![(IF_MATCH, etag.to_string())];
+            let timeout = Duration::from_secs(60);
+            let (_status_code, _resp_body, _resp_headers): (
+                _,
+                Option<HashMap<String, serde_json::Value>>,
+                Option<HeaderMap>,
+            ) = self
+                .s
+                .client
+                .req(
+                    Method::PATCH,
+                    &url,
+                    Some(data),
+                    Some(timeout),
+                    None,
+                    headers,
+                )
+                .await?;
+            Ok(None)
         })
     }
 
@@ -1547,59 +1608,6 @@ impl Bmc {
             ordered.push(format!("Boot{}", b.id).to_string());
         }
         Ok(Some(ordered))
-    }
-
-    async fn set_boot_override(
-        &self,
-        override_target: BootSourceOverrideTarget,
-        override_enabled: BootSourceOverrideEnabled,
-    ) -> Result<(), RedfishError> {
-        let mut boot_data: HashMap<String, String> = HashMap::new();
-        boot_data.insert("BootSourceOverrideMode".to_string(), "UEFI".to_string());
-        boot_data.insert(
-            "BootSourceOverrideEnabled".to_string(),
-            format!("{}", override_enabled),
-        );
-        boot_data.insert(
-            "BootSourceOverrideTarget".to_string(),
-            format!("{}", override_target),
-        );
-        let data = HashMap::from([("Boot", boot_data)]);
-        let url = format!("Systems/{}/SD ", self.s.system_id());
-        let (_, body): (_, HashMap<String, serde_json::Value>) = self.s.client.get(&url).await?;
-        let key = "@odata.etag";
-        let etag = body
-            .get(key)
-            .ok_or_else(|| RedfishError::MissingKey {
-                key: key.to_string(),
-                url: url.to_string(),
-            })?
-            .as_str()
-            .ok_or_else(|| RedfishError::InvalidKeyType {
-                key: key.to_string(),
-                expected_type: "Object".to_string(),
-                url: url.to_string(),
-            })?;
-
-        let headers: Vec<(HeaderName, String)> = vec![(IF_MATCH, etag.to_string())];
-        let timeout = Duration::from_secs(60);
-        let (_status_code, _resp_body, _resp_headers): (
-            _,
-            Option<HashMap<String, serde_json::Value>>,
-            Option<HeaderMap>,
-        ) = self
-            .s
-            .client
-            .req(
-                Method::PATCH,
-                &url,
-                Some(data),
-                Some(timeout),
-                None,
-                headers,
-            )
-            .await?;
-        Ok(())
     }
 
     // nvidia dgx stores the sel as part of the manager

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -49,8 +49,8 @@ use crate::model::{storage::Drives, storage::Storage};
 use crate::network::{RedfishHttpClient, REDFISH_ENDPOINT};
 use crate::{jsonmap, BootOptions, Collection, PCIeDevice, RedfishError, Resource};
 use crate::{
-    model, BiosProfileType, Boot, EnabledDisabled, JobState, NetworkDeviceFunction, NetworkPort,
-    PowerState, Redfish, RoleId, Status, Systems,
+    model, BiosProfileType, Boot, BootOverride, EnabledDisabled, JobState, NetworkDeviceFunction,
+    NetworkPort, PowerState, Redfish, RoleId, Status, Systems,
 };
 use crate::{
     model::chassis::{Chassis, NetworkAdapter},
@@ -421,6 +421,13 @@ impl Redfish for RedfishStandard {
         _target: Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { Err(RedfishError::NotSupported("boot_first".to_string())) })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        _settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { Err(RedfishError::NotSupported("set_boot_override".to_string())) })
     }
 
     fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -29,7 +29,10 @@ use tokio::fs::File;
 use crate::{
     model::{
         account_service::ManagerAccount,
-        boot,
+        boot::{
+            self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
+            BootSourceOverrideTarget,
+        },
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -415,7 +418,23 @@ impl Redfish for Bmc {
 
     /// Boot from this device once then go back to the normal boot order
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.set_boot_override(target, true).await })
+        Box::pin(async move {
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: match target {
+                        Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                        Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                        Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+                    },
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
     }
 
     /// Set which device we should boot from first.
@@ -429,9 +448,50 @@ impl Redfish for Bmc {
                 Err(RedfishError::HTTPErrorCode {
                     status_code: StatusCode::NOT_FOUND,
                     ..
-                }) => self.set_boot_override(target, false).await,
+                }) => {
+                    Redfish::set_boot_override(
+                        self,
+                        BootOverride {
+                            target: match target {
+                                Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                                Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                                Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+                            },
+                            enabled: BootSourceOverrideEnabled::Continuous,
+                            mode: None,
+                            http_boot_uri: None,
+                        },
+                    )
+                    .await?;
+                    Ok(())
+                }
                 res => res,
             }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            // Supermicro BMCs default to UEFI mode when the caller doesn't specify one.
+            let mode = Some(settings.mode.unwrap_or(BootSourceOverrideMode::UEFI));
+            let boot = boot::Boot {
+                boot_source_override_target: Some(settings.target),
+                boot_source_override_enabled: Some(settings.enabled),
+                boot_source_override_mode: mode,
+                http_boot_uri: settings.http_boot_uri,
+                ..Default::default()
+            };
+            let body = HashMap::from([("Boot", boot)]);
+            let url = format!("Systems/{}", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, body)
+                .await
+                .map(|_status_code| ())?;
+            Ok(None)
         })
     }
 
@@ -1421,30 +1481,6 @@ impl Bmc {
             self.s.manager_id()
         );
         let body = HashMap::from([("SysLockdownEnabled", target.is_enabled())]);
-        self.s.client.patch(&url, body).await.map(|_status_code| ())
-    }
-
-    async fn set_boot_override(&self, target: Boot, once: bool) -> Result<(), RedfishError> {
-        let url = format!("Systems/{}", self.s.system_id());
-        let boot = boot::Boot {
-            boot_source_override_target: Some(match target {
-                // In UEFI mode Pxe gets converted to UefiBootNext, but it won't accept
-                // UefiBootNext directly.
-                Boot::Pxe => boot::BootSourceOverrideTarget::Pxe,
-                Boot::HardDisk => boot::BootSourceOverrideTarget::Hdd,
-                // For this one to appear you have to set boot_source_override_mode to UEFI and
-                // reboot, then choose it, then reboot to use it.
-                Boot::UefiHttp => boot::BootSourceOverrideTarget::UefiHttp,
-            }),
-            boot_source_override_enabled: Some(if once {
-                boot::BootSourceOverrideEnabled::Once
-            } else {
-                boot::BootSourceOverrideEnabled::Continuous
-            }),
-            boot_source_override_mode: Some(boot::BootSourceOverrideMode::UEFI),
-            ..Default::default()
-        };
-        let body = HashMap::from([("Boot", boot)]);
         self.s.client.patch(&url, body).await.map(|_status_code| ())
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -431,6 +431,65 @@ async fn run_integration_test(
         redfish.boot_once(libredfish::Boot::Pxe).await?;
         redfish.boot_first(libredfish::Boot::HardDisk).await?;
     }
+
+    // Exercise set_boot_override on vendors that support it. The mockup server
+    // does not validate the PATCH body fwiw -- this just verifies the call path
+    // compiles, dispatches to the right impl, and reaches a writable endpoint.
+    // Mirrors the boot_once/boot_first exclusion above: gbswitch + liteon
+    // mockups don't model the boot-config endpoints, and dell/lenovo return
+    // NotSupported (tested separately below).
+    if vendor_dir != "dell"
+        && vendor_dir != "dell_multi_dpu"
+        && vendor_dir != "lenovo"
+        && vendor_dir != "liteon_powershelf"
+        && vendor_dir != "nvidia_gbswitch"
+    {
+        // Bare override (no mode, no URI). Matches what boot_once/boot_first
+        // do internally for backwards-compatible callers.
+        redfish
+            .set_boot_override(libredfish::BootOverride {
+                target: libredfish::BootSourceOverrideTarget::Pxe,
+                enabled: libredfish::BootSourceOverrideEnabled::Once,
+                mode: None,
+                http_boot_uri: None,
+            })
+            .await?;
+
+        // Full override with explicit UEFI mode and a pinned HTTP boot URI.
+        // This is the new capability -- pinning the URL via the BMC so the host
+        // doesn't have to rely on DHCP option 67.
+        redfish
+            .set_boot_override(libredfish::BootOverride {
+                target: libredfish::BootSourceOverrideTarget::UefiHttp,
+                enabled: libredfish::BootSourceOverrideEnabled::Continuous,
+                mode: Some(libredfish::BootSourceOverrideMode::UEFI),
+                http_boot_uri: Some(
+                    "http://example.invalid/public/blobs/internal/x86_64/ipxe.efi".to_string(),
+                ),
+            })
+            .await?;
+    }
+
+    // Dell and Lenovo return NotSupported until follow-up PRs implement the
+    // BIOS-attribute path (HttpDev1Uri etc. on Dell, equivalent on Lenovo XCC).
+    if vendor_dir == "dell" || vendor_dir == "dell_multi_dpu" || vendor_dir == "lenovo" {
+        match redfish
+            .set_boot_override(libredfish::BootOverride {
+                target: libredfish::BootSourceOverrideTarget::UefiHttp,
+                enabled: libredfish::BootSourceOverrideEnabled::Continuous,
+                mode: Some(libredfish::BootSourceOverrideMode::UEFI),
+                http_boot_uri: Some("http://example.invalid/ipxe.efi".to_string()),
+            })
+            .await
+        {
+            Err(libredfish::RedfishError::NotSupported(_)) => {}
+            other => panic!(
+                "Expected NotSupported for {vendor_dir}, got {:?}",
+                other.map(|_| ())
+            ),
+        }
+    }
+
     redfish
         .power(libredfish::SystemPowerControl::ForceRestart)
         .await?;


### PR DESCRIPTION
This supports https://github.com/NVIDIA/infra-controller/issues/1865.

This PR adds a new `BootOverride` struct and `Redfish::set_boot_override` trait method that exposes full Redfish Boot override support:
- `target` -- e.g. (`UefiHttp`, `Hdd`, etc...)
- `enabled` -- e.g. (`Once`, `Continuous`, `Disabled`)
- `mode` -- e.g. (`UEFI`, `Legacy`)
- `http_boot_uri` -- (an optional `ipxe.efi` URI, which allows us to override DHCP option 67).

The `boot_once`/`boot_first` paths now route through it internally, so existing callers keep their current behavior.

The purpose of this is for upcoming feature work: when `http_boot_uri` is set together with `target = UefiHttp`, the BMC pins the boot URL, and the host will UEFI HTTP boot from it *without* needing DHCP option 67 (which we currently set with `carbide-dhcp`). When `http_boot_uri` is None, the firmware falls back to option 67 per the UEFI HTTP Boot specification. The idea is we can start controlling the `ipxe.efi` boot URL via Redfish and not need to have `carbide-dhcp` populate it via option 67, reducing depdencencies on `carbide-dhcp` as the DHCP server.

Vendor support implemented (via standard Boot resource `PATCH`) for: `nvidia_gh200`, `nvidia_gbx00`, `nvidia_dpu`, `nvidia_viking`, `nvidia_gbswitch`, `hpe`, `supermicro`, `ami`.

Returning `NotSupported` (planned as follow-up PRs) for: `dell`, `lenovo`. Both BMCs require a vendor-specific BIOS-attribute path (`HttpDev1Uri` on iDRAC, XCC equivalent on Lenovo) -- they don't expose the standard `Boot.HttpBootUri` property.

...and then `standard` and `liteon_powershelf` will just stay `NotSupported`.

It currently returns `Result<Option<String>, RedfishError>` -- `Some(job_id)` is reserved for vendors that schedule the change via a BIOS settings job (e.g. future `dell` + `lenovo` impls); current vendors apply immediately and return `None`.

Also fixes a stray trailing space in `Systems/{id}/Settings ` and `Systems/{id}/SD ` URLs across the NVIDIA family vendors.

Tests added.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>