### PR TITLE
feat: add Dell set_boot_override impl via HttpDev1Uri BIOS attribute

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -604,18 +604,85 @@ impl Redfish for Bmc {
         })
     }
 
-    /// Not yet implemented on Dell iDRAC. Dell does not expose the standard
-    /// Redfish `Boot.HttpBootUri` property; setting an HTTP boot URI on Dell
-    /// requires PATCHing the `HttpDev1Uri` and related BIOS attributes via
-    /// `/Systems/{id}/Bios/Settings`. Planned as a follow-up PR.
+    /// Dell iDRAC does not expose the standard Redfish `Boot.HttpBootUri`
+    /// property, and rejects PATCHes to `/Systems/{id}/Settings` that include
+    /// `BootSourceOverrideTarget` or `BootSourceOverrideEnabled` (only
+    /// `Boot.BootOrder` and `Boot.BootSourceOverrideMode` are accepted via
+    /// that endpoint). The Dell-specific path for pinning a UEFI HTTP boot URL
+    /// is via the `HttpDev1Uri` BIOS attribute (plus its `HttpDev1EnDis`,
+    /// `HttpDev1DhcpEnDis`, `HttpDev1Protocol` siblings) PATCH'd to
+    /// `/Systems/{id}/Bios/Settings` with `@Redfish.SettingsApplyTime: OnReset`.
+    ///
+    /// That creates a BIOS config job that applies on next reboot; the job ID
+    /// is returned so callers can `DELETE` it to cancel before reboot.
+    ///
+    /// This has been tested (and verified) on:
+    /// - iDRAC9: R760 (BIOS 2.5.4), R760xd2 (BIOS 1.7.5), XE9680.
+    /// - iDRAC10: R670 (BIOS 1.7.5).
+    ///
+    /// HOWEVER, there seems to be some behavior in OTHER machines that I can't
+    /// quite narrow down, where `HttpDev1Uri.ReadOnly: true` in the BIOS Attribute
+    /// Registry, despite `HttpDev1EnDis: Enabled`. Systems were not in lockdown,
+    /// at least it didn't look like it, so I'm not sure what put those systems
+    /// into that state, and I couldn't actually figure out how to get them
+    /// unlocked (this was as part of running across an entire development fleet).
+    ///
+    /// On these locked hosts, it returns HTTP 400 with a Dell-specific
+    /// MessageId of the form `IDRAC.<ver>.SYS410` ("Unable to modify the
+    /// attribute because the attribute is read-only and depends on other
+    /// attributes"). We translate that specific error into `NotSupported` so
+    /// the caller can fall back to DHCP option 67 for the URL. Any other 400
+    /// or error propagates unchanged.
+    ///
+    /// Once we figure out the weird locked state, callers can opt machines
+    /// into the BMC-pinning path more aggressively.
     fn set_boot_override<'a>(
         &'a self,
-        _settings: BootOverride,
+        settings: BootOverride,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
-            Err(RedfishError::NotSupported(
-                "No Dell set_boot_override implementation".to_string(),
-            ))
+            let Some(uri) = settings.http_boot_uri else {
+                // Dell does not accept BootSourceOverrideTarget/Enabled PATCHes
+                // via /Systems/{id}/Settings. Without an http_boot_uri to set
+                // via the BIOS attribute path, there's no Dell-specific
+                // operation for this method to perform.
+                return Err(RedfishError::NotSupported(
+                    "Dell set_boot_override requires http_boot_uri; BootSourceOverrideTarget/Enabled are not settable via Redfish on iDRAC".to_string(),
+                ));
+            };
+
+            let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
+            let body = serde_json::json!({
+                "@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"},
+                "Attributes": {
+                    "HttpDev1Uri": uri,
+                    "HttpDev1EnDis": "Enabled",
+                    "HttpDev1DhcpEnDis": "Disabled",
+                    "HttpDev1Protocol": "IPv4",
+                }
+            });
+
+            match self.s.client.patch(&url, body).await {
+                Ok((_, Some(headers))) => {
+                    let job_id = self
+                        .parse_job_id_from_response_headers(&url, headers)
+                        .await?;
+                    Ok(Some(job_id))
+                }
+                Ok((_, None)) => Err(RedfishError::NoHeader),
+                Err(RedfishError::HTTPErrorCode {
+                    status_code,
+                    response_body,
+                    ..
+                }) if status_code == StatusCode::BAD_REQUEST
+                    && response_body.contains("SYS410") =>
+                {
+                    Err(RedfishError::NotSupported(format!(
+                        "Dell iDRAC rejected HttpDev1Uri PATCH as ReadOnly (MessageId SYS410). Response: {response_body}"
+                    )))
+                }
+                Err(e) => Err(e),
+            }
         })
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -494,9 +494,41 @@ async fn run_integration_test(
             .await?;
     }
 
-    // Dell and Lenovo return NotSupported until follow-up PRs implement the
-    // BIOS-attribute path (HttpDev1Uri etc. on Dell, equivalent on Lenovo XCC).
-    if vendor_dir == "dell" || vendor_dir == "dell_multi_dpu" || vendor_dir == "lenovo" {
+    // Dell mockups use the patch_response.json side-file mechanism in the
+    // Python mockup server to simulate real iDRAC responses to PATCH
+    // /Bios/Settings:
+    //   - `dell` mockup: returns 202 + Location header → impl parses the
+    //     job ID out of Location and returns Ok(Some(job_id)). Exercises
+    //     the success path.
+    //   - `dell_multi_dpu` mockup: returns 400 with the Dell-specific SYS410
+    //     MessageId in the body → impl translates that to NotSupported.
+    //     Exercises the read-only-attribute failure path.
+    if vendor_dir == "dell" {
+        match redfish
+            .set_boot_override(libredfish::BootOverride {
+                target: libredfish::BootSourceOverrideTarget::UefiHttp,
+                enabled: libredfish::BootSourceOverrideEnabled::Continuous,
+                mode: Some(libredfish::BootSourceOverrideMode::UEFI),
+                http_boot_uri: Some("http://example.invalid/ipxe.efi".to_string()),
+            })
+            .await
+        {
+            Ok(Some(job_id)) => {
+                assert_eq!(
+                    job_id, "JID_900000000001",
+                    "Expected job ID parsed from mockup's Location header"
+                );
+            }
+            other => panic!(
+                "Expected Ok(Some(job_id)) for {vendor_dir}, got {:?}",
+                other.map(Some)
+            ),
+        }
+    }
+
+    // dell_multi_dpu (mockup-simulated SYS410 lock) and lenovo (no impl)
+    // both return NotSupported.
+    if vendor_dir == "dell_multi_dpu" || vendor_dir == "lenovo" {
         match redfish
             .set_boot_override(libredfish::BootOverride {
                 target: libredfish::BootSourceOverrideTarget::UefiHttp,

--- a/tests/mockups/dell/redfish/v1/Systems/System.Embedded.1/Bios/Settings/patch_response.json
+++ b/tests/mockups/dell/redfish/v1/Systems/System.Embedded.1/Bios/Settings/patch_response.json
@@ -1,0 +1,9 @@
+{
+    "match_request_body_contains": "HttpDev1Uri",
+    "status": 202,
+    "headers": {
+        "Content-Type": "application/json",
+        "Location": "/redfish/v1/TaskService/Tasks/JID_900000000001"
+    },
+    "body": "{\"@Message.ExtendedInfo\":[{\"Message\":\"Successfully scheduled the job.\",\"MessageArgs\":[],\"MessageId\":\"IDRAC.2.9.JCP001\",\"Severity\":\"OK\"}]}"
+}

--- a/tests/mockups/dell_multi_dpu/redfish/v1/Systems/System.Embedded.1/Bios/Settings/patch_response.json
+++ b/tests/mockups/dell_multi_dpu/redfish/v1/Systems/System.Embedded.1/Bios/Settings/patch_response.json
@@ -1,0 +1,8 @@
+{
+    "match_request_body_contains": "HttpDev1Uri",
+    "status": 400,
+    "headers": {
+        "Content-Type": "application/json"
+    },
+    "body": "{\"error\":{\"@Message.ExtendedInfo\":[{\"Message\":\"Unable to modify the attribute because the attribute is read-only and depends on other attributes.\",\"MessageArgs\":[\"HttpDev1Uri\"],\"MessageId\":\"IDRAC.2.16.SYS410\",\"RelatedProperties\":[\"#/Attributes/HttpDev1Uri\"],\"Severity\":\"Warning\",\"Resolution\":\"Verify if the attribute has dependency on other attributes and retry the operation.\"}],\"code\":\"Base.1.18.GeneralError\",\"message\":\"A general error has occurred. See ExtendedInfo for more information.\"}}"
+}

--- a/tests/redfishMockupServer.py
+++ b/tests/redfishMockupServer.py
@@ -711,6 +711,32 @@ class RfMockupServer(BaseHTTPRequestHandler):
         if data_received:
             logger.info("   PATCH: Data: {}".format(data_received))
 
+            # If a canned PATCH response file exists at the resource path
+            # (patch_response.json), use it instead of the default merge+204.
+            # Lets vendor mockups simulate real-BMC responses like
+            # "202 + Location header" (success) or "400 + vendor-specific
+            # error MessageId" (failure).
+            #
+            # The canned response file can optionally include a top-level
+            # `match_request_body_contains` (string or list of strings); when
+            # present, the canned response is only used if the request body
+            # contains any of those substrings. This lets us target a
+            # specific PATCH operation on a shared endpoint without
+            # intercepting other PATCHes to the same resource.
+            patch_response_fpath = self.construct_path(self.path, "patch_response.json")
+            if os.path.isfile(patch_response_fpath):
+                use_canned = True
+                with open(patch_response_fpath) as f:
+                    canned = json.load(f)
+                match = canned.get("match_request_body_contains")
+                if match is not None:
+                    needles = match if isinstance(match, list) else [match]
+                    raw_body = json.dumps(data_received)
+                    use_canned = any(n in raw_body for n in needles)
+                if use_canned:
+                    self.send_response_file(patch_response_fpath)
+                    return
+
             # construct path "mockdir/path/to/resource/<filename>"
             fpath = self.construct_path(self.path, "index.json")
             success, payload = self.get_cached_link(fpath)


### PR DESCRIPTION
This supports https://github.com/NVIDIA/infra-controller/issues/1865.

Implements `set_boot_override` for Dell iDRAC by PATCHing the `HttpDev1Uri`-related BIOS attributes via `/Systems/{id}/Bios/Settings`. Returns the BIOS config job ID; callers can DELETE it to cancel before the BIOS reboot if needed.

Worth noting Dell doesn't expose the standard Redfish `Boot.HttpBootUri` property, and also rejects PATCHing `BootSourceOverrideTarget/Enabled` via `/Systems/{id}/Settings` (only `Boot.BootOrder` and `BootSourceOverrideMode` are accepted there). The `HttpDev1Uri` attribute is the Dell-documented path for pinning UEFI HTTP boot URLs.

Verified end-to-end on hosts in a development lab:
- iDRAC9: R760 (BIOS 2.5.4), R760xd2 (BIOS 1.7.5), XE9680 (some).
- iDRAC10: R670 (BIOS 1.7.5).

Integration tests cover both paths:
- dell mockup (`HttpDev1Uri.ReadOnly=false`) exercises the `PATCH` path.
- dell_multi_dpu mockup (`HttpDev1Uri.ReadOnly=true`) exercises the locked path.

Note that there seemed to be some machines that were reporting as being locked/read-only, even though they didn't appear to be in lockdown. Not really sure what was going on there, but if for some reason the PATCHing fails, we'll just return the error (and it will be up to the caller to decide what they want to do).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>