### PR TITLE
feat: implement HPE set_boot_override via UrlBootFile BIOS attribute

### DIFF
--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -27,7 +27,7 @@ use serde_json::Value;
 use crate::{
     model::{
         account_service::ManagerAccount,
-        boot::{BootOverride, BootSourceOverrideMode},
+        boot::BootOverride,
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -476,34 +476,64 @@ impl Redfish for Bmc {
         Box::pin(async move { self.boot_first(target).await })
     }
 
+    /// HPE iLO does not implement the standard Redfish `Boot.HttpBootUri`
+    /// PATCH path. The `HttpBootUri` field appears in the Boot block (as
+    /// `null` in GET responses) and `UefiHttp` is advertised in
+    /// `BootSourceOverrideTarget@Redfish.AllowableValues`, but PATCHing
+    /// either rejects with `PropertyNotWritableOrUnknown` and
+    /// `UnsupportedOperation` respectively. In fact, the entire
+    /// `BootSourceOverride` PATCH mechanism is non-functional on iLO 6
+    /// (at least in v1.58); even `BootSourceOverrideTarget: "Pxe"` is
+    /// rejected.
+    ///
+    /// The HPE-specific path for pinning a UEFI HTTP boot URL is the
+    /// `UrlBootFile` BIOS attribute (with optional `UrlBootFile2/3/4`
+    /// secondaries and `PreBootNetwork` for IPv4/IPv6/Auto). Setting it
+    /// creates a UEFI boot entry called "URL File" pointing at the URI;
+    /// applies on next reset. Equivalent to the iLO HPREST/ilorest
+    /// `select Bios; set UrlBootFile=...; commit` workflow, which is
+    /// documented on Gen10/iLO 5 and Gen11/iLO 6.
+    ///
+    /// Verified working on ProLiant DL380a Gen11 machines (running both
+    /// iLO 6 v1.58 and v1.72). Unlike Dell, there doesn't seem to be any
+    /// sort of attribute engine dependency drama going on; UrlBootFile is
+    /// a straightforward string attribute that's writable across the fleet.
+    ///
+    /// Returns `Ok(None)` on success: HPE doesn't return a Location/job ID
+    /// here (unlike Dell). The pending state lives in `/Bios/Settings` and
+    /// applies on next reboot; the response includes `SystemResetRequired`
+    /// as confirmation that the change is staged.
+    /// Callers reverting the change PATCH `UrlBootFile: ""` back.
     fn set_boot_override<'a>(
         &'a self,
         settings: BootOverride,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
-            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
-            boot_data.insert(
-                "BootSourceOverrideTarget".to_string(),
-                settings.target.to_string().into(),
-            );
-            boot_data.insert(
-                "BootSourceOverrideEnabled".to_string(),
-                settings.enabled.to_string().into(),
-            );
-            // HPE iLO defaults to UEFI mode when the caller doesn't specify one.
-            let mode = settings.mode.unwrap_or(BootSourceOverrideMode::UEFI);
-            boot_data.insert(
-                "BootSourceOverrideMode".to_string(),
-                mode.to_string().into(),
-            );
-            if let Some(uri) = settings.http_boot_uri {
-                boot_data.insert("HttpBootUri".to_string(), uri.into());
-            }
-            let url = format!("Systems/{}", self.s.system_id());
-            self.s
-                .client
-                .patch(&url, HashMap::from([("Boot", boot_data)]))
-                .await?;
+            let Some(uri) = settings.http_boot_uri else {
+                // HPE iLO 6 does not accept BootSourceOverrideTarget/Enabled
+                // PATCHes. Even non-HTTP targets like Pxe are rejected with
+                // UnsupportedOperation. Without an http_boot_uri to set via
+                // the UrlBootFile BIOS attribute, no Redfish operation here.
+                return Err(RedfishError::NotSupported(
+                    "HPE set_boot_override requires http_boot_uri; \
+                     BootSourceOverrideTarget/Enabled PATCHes are not \
+                     functional via Redfish on iLO 6 (verified on v1.58 / \
+                     v1.72: UnsupportedOperation for all override targets)"
+                        .to_string(),
+                ));
+            };
+
+            // HPE iLO uses lowercase `settings/` in its @Redfish.Settings
+            // pointer (matches the existing helpers in this file, e.g.,
+            // setup_serial_console / clear_tpm).
+            let url = format!("Systems/{}/Bios/settings/", self.s.system_id());
+            let body = serde_json::json!({
+                "Attributes": {
+                    "UrlBootFile": uri,
+                    "PreBootNetwork": "IPv4",
+                }
+            });
+            self.s.client.patch(&url, body).await?;
             Ok(None)
         })
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -432,17 +432,24 @@ async fn run_integration_test(
         redfish.boot_first(libredfish::Boot::HardDisk).await?;
     }
 
-    // Exercise set_boot_override on vendors that support it. The mockup server
-    // does not validate the PATCH body fwiw -- this just verifies the call path
+    // Exercise set_boot_override on vendors that support the bare (no URI)
+    // override variant via the standard Redfish Boot block PATCH. The mockup
+    // doesn't validate the PATCH body -- this just verifies the call path
     // compiles, dispatches to the right impl, and reaches a writable endpoint.
-    // Mirrors the boot_once/boot_first exclusion above: gbswitch + liteon
-    // mockups don't model the boot-config endpoints, and dell/lenovo return
-    // NotSupported (tested separately below).
+    //
+    // Excluded:
+    //   gbswitch + liteon: mockups don't model the boot-config endpoints
+    //   dell/dell_multi_dpu: tested separately below (BIOS-attribute path)
+    //   lenovo: returns NotSupported (tested separately below)
+    //   hpe: returns NotSupported when http_boot_uri is absent (BIOS-attribute
+    //        path via UrlBootFile is the only HPE-functional mechanism;
+    //        BootSourceOverride PATCHes are rejected by iLO 6 firmware)
     if vendor_dir != "dell"
         && vendor_dir != "dell_multi_dpu"
         && vendor_dir != "lenovo"
         && vendor_dir != "liteon_powershelf"
         && vendor_dir != "nvidia_gbswitch"
+        && vendor_dir != "hpe"
     {
         // Bare override (no mode, no URI). Matches what boot_once/boot_first
         // do internally for backwards-compatible callers.
@@ -458,6 +465,23 @@ async fn run_integration_test(
         // Full override with explicit UEFI mode and a pinned HTTP boot URI.
         // This is the new capability -- pinning the URL via the BMC so the host
         // doesn't have to rely on DHCP option 67.
+        redfish
+            .set_boot_override(libredfish::BootOverride {
+                target: libredfish::BootSourceOverrideTarget::UefiHttp,
+                enabled: libredfish::BootSourceOverrideEnabled::Continuous,
+                mode: Some(libredfish::BootSourceOverrideMode::UEFI),
+                http_boot_uri: Some(
+                    "http://example.invalid/public/blobs/internal/x86_64/ipxe.efi".to_string(),
+                ),
+            })
+            .await?;
+    }
+
+    // HPE uses the UrlBootFile BIOS-attribute path. The mockup accepts the
+    // PATCH (default 204 No Content), and the impl returns Ok(None) since HPE
+    // doesn't surface a job ID for BIOS attribute changes. Bare override (no
+    // URI) returns NotSupported on HPE -- we only test the URI-supplied path.
+    if vendor_dir == "hpe" {
         redfish
             .set_boot_override(libredfish::BootOverride {
                 target: libredfish::BootSourceOverrideTarget::UefiHttp,


### PR DESCRIPTION
This supports https://github.com/NVIDIA/infra-controller/issues/1865.

The existing impl PATCHed the standard Redfish `Boot.HttpBootUri` at `/Systems/{id}`, but iLO (at least iLO 6) doesn't actually implement that; the entire BootSourceOverride PATCH path is non-functional. Even non-HTTP targets like `Pxe` return `UnsupportedOperation`, and `HttpBootUri` itself returns `PropertyNotWritableOrUnknown`. The field exists in the response schema for compliance, BUT the firmware isn't wired up to honor `PATCH`es to it.

The actual HPE path is the `UrlBootFile` BIOS attribute (with `UrlBootFile2/3/4` secondaries and `PreBootNetwork` for IPv4/IPv6/Auto), which is `PATCH`ed at `/Systems/{id}/Bios/settings/`. This is a very similar pattern that Dell uses with `HttpDev1Uri`, just with an HPE-specific attribute name. Setting it creates a UEFI boot entry called "URL File" pointing at the URI, which applies on next reset. It is equivalent to the documented `HPREST/ilorest` flow `select Bios; set UrlBootFile=...; commit`.

Verified on HPE ProLiant DL380a Gen11 gear with:
- iLO 6 v1.58
- iLO 6 v1.72

In testing:
- `ServerConfigLockState` was `Disabled` across all sampled machines.
- `UrlBootFile.ReadOnly`  was `false` in the registry.
- `PATCH` returned HTTP 200 + `SystemResetRequired`.
- Rollback works cleanly a `PATCH` of the `UrlBootFile` back to `""`.

Unlike some situations I was running into with Dell gear, the attribute is consistently writable across the fleet sample I checked.

Returns `Ok(None)` on success (since HPE doesn't surface a job ID for BIOS attribute changes; pending state lives in `/Bios/settings/` and applies on next reboot).

Note! `boot_once` and `boot_first` on HPE are unchanged. Those both use the existing HPE OEM `PersistentBootConfigOrder` mechanism at `/Systems/{id}/Bios/oem/hpe/boot/settings/` and are independent of this code path.

Integration test updated. HPE testing now exercises the BIOS-attribute path with an `http_boot_uri` provided (the only HPE-supported mode), and is excluded from the bare-override loop (where `set_boot_override` is called without `http_boot_uri`) since that returns `NotSupported` on HPE by design.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>