### PR TITLE
feat: support interface ID on machine_setup via BootInterfaceRef

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -331,7 +331,7 @@ impl Redfish for Bmc {
     /// 3. BIOS settings
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -354,9 +354,17 @@ impl Redfish for Bmc {
     /// Check machine setup status for AMI BMC.
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
             if let Some(mac) = boot_interface_mac {
@@ -389,7 +397,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let diffs = self.diff_bios_bmc_attr().await?;

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -270,7 +270,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
         bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -288,11 +288,14 @@ impl Redfish for Bmc {
                 apply_time: dell::RedfishSettingsApplyTime::OnReset, // requires reboot to apply
             };
 
-            let (nic_slot, has_dpu) = match boot_interface_mac {
-                Some(mac) => {
+            let (nic_slot, has_dpu) = match boot_interface {
+                Some(crate::BootInterfaceRef::Mac(mac)) => {
                     let slot: String = self.dpu_nic_slot(mac).await?;
                     (slot, true)
                 }
+                // Caller already knows the interface id/interface partition id,
+                // so skip the MAC lookup and use the interface provided.
+                Some(crate::BootInterfaceRef::InterfaceId(id)) => (id.to_string(), true),
                 // Zero-DPU case
                 None => ("".to_string(), false),
             };
@@ -367,9 +370,17 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             // Check BIOS and BMC attributes
             let mut diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
 
@@ -1313,9 +1324,15 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
+            // See `machine_setup_status` above for the resolver pattern.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
             let diffs = self.diff_bios_bmc_attr(boot_interface_mac).await?;
             Ok(diffs.is_empty())
         })

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -276,7 +276,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -299,9 +299,17 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             // Check BIOS and BMC attributes
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
@@ -1133,7 +1141,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let diffs = self.diff_bios_bmc_attr().await?;

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -251,7 +251,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -310,9 +310,17 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             // Check BIOS and BMC attributes
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
@@ -1166,7 +1174,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let diffs = self.diff_bios_bmc_attr().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,13 @@ pub trait Redfish: Send + Sync + 'static {
 
     /// Sets up a reasonable UEFI configuration.
     /// remember to call lockdown() afterwards to secure the server
-    /// - boot_interface_mac: MAC Address of the NIC you wish to boot from
+    /// - boot_interface: identifies the NIC you wish to boot from. Either a
+    ///   `BootInterfaceRef::Mac` (existing behavior: vendor impl looks up
+    ///   the partition by MAC via its BMC enumeration) or a
+    ///   `BootInterfaceRef::InterfaceId` (vendor-native Redfish
+    ///   `EthernetInterface.Id` — used when we already know the interface
+    ///   partition ID (and don't need to look it up by MAC). One case
+    ///   being if we flip a DPU to NIC mode.
     ///   If not given we look for a Mellanox Bluefield DPU and use that.
     ///   Not applicable to Supermicro and the DPU itself.
     ///   bios_profiles: Map of vendor/model (with spaces replaced by underscores)/profile/type
@@ -234,7 +240,7 @@ pub trait Redfish: Send + Sync + 'static {
     /// Ok(None) when no job is created. Caller should wait for job completion before configuring boot order.
     fn machine_setup<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<BootInterfaceRef<'a>>,
         bios_profiles: &'a BiosProfileVendor,
         selected_profile: BiosProfileType,
         oem_manager_profiles: &'a BiosProfileVendor,
@@ -243,13 +249,13 @@ pub trait Redfish: Send + Sync + 'static {
     /// Is everything that machine_setup does already done?
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<BootInterfaceRef<'a>>,
     ) -> RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>>;
 
     /// Check if only the BIOS/BMC setup is done
     fn is_bios_setup<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<BootInterfaceRef<'a>>,
     ) -> RedfishFuture<'a, Result<bool, RedfishError>>;
 
     /// Apply a standard BMC password policy. This varies a lot by vendor,
@@ -754,6 +760,68 @@ impl Status {
     }
 }
 
+/// How a caller identifies a boot interface to [`Redfish::machine_setup`]
+/// and supporting query methods. Callers can pass either form; vendor
+/// impls handle both.
+#[derive(Debug, Clone, Copy)]
+pub enum BootInterfaceRef<'a> {
+    /// MAC address of the boot interface. Vendor impl translates it
+    /// into the vendor-native interface id its BIOS attributes consume.
+    Mac(&'a str),
+    /// Vendor-native Redfish `EthernetInterface.Id` for the boot
+    /// interface (e.g. `"NIC.Slot.7-1-1"`). Vendor impl uses it
+    /// directly.
+    InterfaceId(&'a str),
+}
+
+impl<'a> BootInterfaceRef<'a> {
+    /// Returns the MAC if this is the [`BootInterfaceRef::Mac`] variant.
+    /// Returns `None` if this is the [`BootInterfaceRef::InterfaceId`]
+    /// variant.
+    pub fn mac(&self) -> Option<&'a str> {
+        match self {
+            BootInterfaceRef::Mac(mac) => Some(mac),
+            BootInterfaceRef::InterfaceId(_) => None,
+        }
+    }
+}
+
+/// Returns the MAC address for a [`BootInterfaceRef`].
+/// [`BootInterfaceRef::Mac`] is a pass-through; [`BootInterfaceRef::InterfaceId`]
+/// is resolved by fetching `Systems/{}/EthernetInterfaces/{id}` via the
+/// Redfish-standard `EthernetInterface` resource (every vendor
+/// implements it).
+///
+/// Used by methods that compare against a MAC (verification paths that
+/// walk boot options by MAC substring, etc.) so the caller can pass
+/// either [`BootInterfaceRef`] variant uniformly.
+pub async fn resolve_boot_interface_mac<R: Redfish + ?Sized>(
+    redfish: &R,
+    boot_interface: BootInterfaceRef<'_>,
+) -> Result<String, RedfishError> {
+    match boot_interface {
+        BootInterfaceRef::Mac(mac) => Ok(mac.to_string()),
+        BootInterfaceRef::InterfaceId(id) => {
+            let eif = redfish.get_system_ethernet_interface(id).await?;
+            extract_resolved_mac(eif.mac_address.as_deref(), id)
+        }
+    }
+}
+
+/// Pure half of [`resolve_boot_interface_mac`], split out for unit
+/// tests. Returns the MAC if non-empty; errors otherwise rather than
+/// passing an empty string through to downstream `.contains(&mac)`
+/// matchers (which would match every option for an empty needle).
+fn extract_resolved_mac(mac: Option<&str>, id: &str) -> Result<String, RedfishError> {
+    let mac = mac.unwrap_or("");
+    if mac.is_empty() {
+        return Err(RedfishError::GenericError {
+            error: format!("Systems/.../EthernetInterfaces/{id} has no populated MACAddress"),
+        });
+    }
+    Ok(mac.to_string())
+}
+
 #[derive(Debug)]
 pub struct MachineSetupStatus {
     pub is_done: bool,
@@ -836,4 +904,50 @@ pub type BiosProfileVendor = HashMap<RedfishVendor, BiosProfileModel>;
 // Simplify model names so that we can put them in toml files as categories
 pub fn model_coerce(original: &str) -> String {
     str::replace(original, " ", "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boot_interface_ref_mac_returns_inner() {
+        let mac = "aa:bb:cc:dd:ee:01";
+        let r = BootInterfaceRef::Mac(mac);
+        assert_eq!(r.mac(), Some(mac));
+    }
+
+    #[test]
+    fn boot_interface_ref_interface_id_mac_is_none() {
+        let r = BootInterfaceRef::InterfaceId("NIC.Slot.7-1-1");
+        assert!(r.mac().is_none());
+    }
+
+    #[test]
+    fn extract_resolved_mac_passes_through_populated_mac() {
+        let got = super::extract_resolved_mac(Some("AA:BB:CC:DD:EE:01"), "NIC.Slot.7-1-1")
+            .expect("populated MAC should be returned as-is");
+        assert_eq!(got, "AA:BB:CC:DD:EE:01");
+    }
+
+    #[test]
+    fn extract_resolved_mac_errors_on_empty_string_mac() {
+        // An empty MAC must error rather than pass through —
+        // downstream `display_name.contains(&mac)` matchers would
+        // otherwise match every boot option for an empty needle.
+        let err = super::extract_resolved_mac(Some(""), "NIC.Slot.7-1-1")
+            .expect_err("empty MAC should be an explicit error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NIC.Slot.7-1-1"),
+            "error should name the interface id; got: {msg}",
+        );
+    }
+
+    #[test]
+    fn extract_resolved_mac_errors_on_missing_mac_field() {
+        let err = super::extract_resolved_mac(None, "NIC.Slot.7-1-1")
+            .expect_err("None MAC should be an explicit error");
+        assert!(err.to_string().contains("NIC.Slot.7-1-1"));
+    }
 }

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -223,7 +223,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -242,7 +242,7 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
             let diffs = vec![];
@@ -842,7 +842,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move { Err(RedfishError::NotSupported("not supported".to_string())) })
     }

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -235,7 +235,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -261,7 +261,7 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
             let mut diffs = vec![];
@@ -1015,10 +1015,10 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            let status = self.machine_setup_status(boot_interface_mac).await?;
+            let status = self.machine_setup_status(boot_interface).await?;
             Ok(status.is_done)
         })
     }

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -259,7 +259,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -275,7 +275,7 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
             let diffs = vec![];
@@ -1048,7 +1048,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -509,7 +509,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -538,9 +538,17 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             // Check BIOS and BMC attributes
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
@@ -1240,7 +1248,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let diffs = self.diff_bios_bmc_attr().await?;

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -225,7 +225,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -245,7 +245,7 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
             let mut diffs = vec![];
@@ -996,7 +996,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -245,7 +245,7 @@ impl Redfish for Bmc {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -264,9 +264,17 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             // Check BIOS and BMC attributes
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
@@ -1204,7 +1212,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let diffs = self.diff_bios_bmc_attr().await?;

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -321,7 +321,7 @@ impl Redfish for RedfishStandard {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -337,7 +337,7 @@ impl Redfish for RedfishStandard {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(
@@ -1144,7 +1144,7 @@ impl Redfish for RedfishStandard {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move { Err(RedfishError::NotSupported("is_bios_setup".to_string())) })
     }

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -215,7 +215,7 @@ impl Redfish for Bmc {
     /// but it won't show until after reboot so that step will fail on first time through.
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
@@ -244,9 +244,17 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        boot_interface_mac: Option<&'a str>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
             // Check BIOS and BMC attributes
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
@@ -1102,7 +1110,7 @@ impl Redfish for Bmc {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface_mac: Option<&'a str>,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let diffs = self.diff_bios_bmc_attr().await?;


### PR DESCRIPTION
Enhances the `boot_interface_mac: Option<&str>` parameter on `machine_setup`, `machine_setup_status`, and `is_bios_setup` with a new `boot_interface: Option<BootInterfaceRef>`, which is an enum whose variants are `Mac` (existing behavior) and `InterfaceId`.

The problem we're running into is when we flip a DPU from DPU mode to NIC mode, we run into this state where the `NetworkDeviceFunction` becomes `Disabled` (because it's now in NIC mode), and since the interface changed, it gets wiped as a boot device (and boot device goes back to `Disabled` with the default integraed NIC).

..AND when we go to `machine_setup` with the known MAC, that fails, because as part of switching from DPU mode to NIC mode (and the device function being reported as `Disabled`, it appears the vendor hardware doesn't re-probe the interface, so it doesn't populate a MAC address, so `machine_setup` fails, because there's no matching MAC address across all of these):
  * `Chassis/.../NetworkDeviceFunctions/<id>.Ethernet.MACAddress`
  * `Systems/.../EthernetInterfaces/<id>.MACAddress`
  * `Chassis/.../NetworkAdapters/<adapter>/NetworkPorts/<id>` fields

However, if we just directly set the boot interface back to the previously set boot interface from before the flip, it forces a re-probe that interface partition ID, the MAC re-populates, and it UEFI HTTP boots.

I had tried flipping the NDF back to `Enabled`, but it looks like some BMCs ALSO lock the `Enable` knob: `NetworkDeviceFunction.NetDevFuncCapabilities` is published as `["Disabled"]`, so the `NetDevFuncType` field literally can't be PATCHed away from `Disabled` via the NDF Settings URL. The only mechanism that actually activates a Disabled partition is to PATCH the vendor's HTTP-boot binding BIOS attribute to the partition's id and reboot — BIOS at POST then enables the underlying PCI function as a side effect, and the BMC re-inventories the MAC. That side-effect path is exactly what `machine_setup` already does; the only obstacle was that it derived the id from a MAC the BMC had wiped. By accepting an `InterfaceId` directly, callers that captured the id earlier (typically site-explorer during initial discovery, before the partition went Disabled) skip the broken lookup.

So, this adds support to just let us specify the interface ID directly, and not need to pass a MAC to do a MAC -> interface ID lookup.

This will have a corresponding change on the NICo side as well as part of pulling it in.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>