### PR TITLE
feat: BootInterfaceRef::Mac takes MacAddress instead of &str

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 version-compare = { version = "0.1" }
 regex = "1.10"
+mac_address = "1.1"
 chrono = { version = "0.4.34", features = ["serde"] }
 urlencoding = "2.1.3"
 

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -290,7 +290,7 @@ impl Redfish for Bmc {
 
             let (nic_slot, has_dpu) = match boot_interface {
                 Some(crate::BootInterfaceRef::Mac(mac)) => {
-                    let slot: String = self.dpu_nic_slot(mac).await?;
+                    let slot: String = self.dpu_nic_slot(&mac.to_string()).await?;
                     (slot, true)
                 }
                 // Caller already knows the interface id/interface partition id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,22 +765,22 @@ impl Status {
 /// impls handle both.
 #[derive(Debug, Clone, Copy)]
 pub enum BootInterfaceRef<'a> {
-    /// MAC address of the boot interface. Vendor impl translates it
-    /// into the vendor-native interface id its BIOS attributes consume.
-    Mac(&'a str),
+    /// MAC address of the boot interface. Vendor impl translates it into
+    /// the vendor-native interface id its BIOS attributes consume.
+    Mac(mac_address::MacAddress),
     /// Vendor-native Redfish `EthernetInterface.Id` for the boot
     /// interface (e.g. `"NIC.Slot.7-1-1"`). Vendor impl uses it
     /// directly.
     InterfaceId(&'a str),
 }
 
-impl<'a> BootInterfaceRef<'a> {
+impl BootInterfaceRef<'_> {
     /// Returns the MAC if this is the [`BootInterfaceRef::Mac`] variant.
     /// Returns `None` if this is the [`BootInterfaceRef::InterfaceId`]
     /// variant.
-    pub fn mac(&self) -> Option<&'a str> {
+    pub fn mac(&self) -> Option<mac_address::MacAddress> {
         match self {
-            BootInterfaceRef::Mac(mac) => Some(mac),
+            BootInterfaceRef::Mac(mac) => Some(*mac),
             BootInterfaceRef::InterfaceId(_) => None,
         }
     }
@@ -912,7 +912,7 @@ mod tests {
 
     #[test]
     fn boot_interface_ref_mac_returns_inner() {
-        let mac = "aa:bb:cc:dd:ee:01";
+        let mac: mac_address::MacAddress = "AA:BB:CC:DD:EE:01".parse().unwrap();
         let r = BootInterfaceRef::Mac(mac);
         assert_eq!(r.mac(), Some(mac));
     }


### PR DESCRIPTION
This supports https://github.com/NVIDIA/infra-controller/issues/2169.

Small follow-up to nvidia/libredfish#81 (the `BootInterfaceRef` enum). The `Mac` variant now takes a typed `mac_address::MacAddress` instead of a raw `&str`, giving us type safety, AND so callers that already have a `MacAddress` can pass it straight through without stringifying first.

On the NICo/caller side, this also means we can write things like `.machine_setup(boot_interface.into(), ...)` instead of juggling a temporary string.

There are a bunch of call sites that should take a `MacAddress` too, but I'll do those later.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>