### PR TITLE
feat: accept BootInterfaceRef on set_boot_order_dpu_first + is_boot_order_setup

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -925,13 +925,15 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.get_collection(id).await })
     }
 
-    /// Set the DPU (identified by MAC address) as the first boot option.
+    /// Set the DPU as the first boot option.
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        mac_address: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
-            let mac = mac_address.to_uppercase();
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface)
+                .await?
+                .to_uppercase();
             let (system, all_boot_options) = self.get_system_and_boot_options().await?;
 
             let target = all_boot_options.iter().find(|opt| {
@@ -945,7 +947,7 @@ impl Redfish for Bmc {
                     .map(|b| format!("{}: {}", b.id, b.display_name))
                     .collect();
                 return Err(RedfishError::MissingBootOption(format!(
-                    "No HTTP IPv4 boot option found for MAC {mac_address}; available: {:#?}",
+                    "No HTTP IPv4 boot option found for MAC {mac}; available: {:#?}",
                     all_names
                 )));
             };
@@ -954,9 +956,7 @@ impl Redfish for Bmc {
             let mut boot_order = system.boot.boot_order;
 
             if boot_order.first() == Some(&target_id) {
-                tracing::info!(
-                    "NO-OP: DPU ({mac_address}) is already first in boot order ({target_id})"
-                );
+                tracing::info!("NO-OP: DPU ({mac}) is already first in boot order ({target_id})");
                 return Ok(None);
             }
 
@@ -970,12 +970,11 @@ impl Redfish for Bmc {
     /// Check if boot order is setup correctly
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
-                .await?;
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
             Ok(expected.is_some() && expected == actual)
         })
     }

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -63,6 +63,32 @@ const UEFI_PASSWORD_NAME: &str = "SetupPassword";
 
 const MAX_ACCOUNT_ID: u8 = 16;
 
+/// Match a Dell `NetworkDeviceFunction` against a [`BootInterfaceRef`].
+///
+/// - [`BootInterfaceRef::Mac`] matches when the NDF's `Ethernet.MACAddress`
+///   equals the target (case-insensitive).
+/// - [`BootInterfaceRef::InterfaceId`] matches when the NDF's `Id` is a
+///   prefix of the target (with a `-` boundary) -- e.g. NDF `NIC.Slot.7-1`
+///   matches partition `NIC.Slot.7-1-1`. Equality also matches. This lets us
+///   locate the NDF for partitions whose MAC has been stripped (the
+///   NicMode-Disabled case).
+fn nw_dev_func_matches(
+    nw_dev_func: &NetworkDeviceFunction,
+    boot_interface: crate::BootInterfaceRef<'_>,
+) -> bool {
+    match boot_interface {
+        crate::BootInterfaceRef::Mac(target) => nw_dev_func
+            .ethernet
+            .as_ref()
+            .and_then(|e| e.mac_address.as_ref())
+            .is_some_and(|m| m.eq_ignore_ascii_case(&target.to_string())),
+        crate::BootInterfaceRef::InterfaceId(target) => nw_dev_func
+            .id
+            .as_deref()
+            .is_some_and(|ndf_id| target == ndf_id || target.starts_with(&format!("{ndf_id}-"))),
+    }
+}
+
 pub struct Bmc {
     s: RedfishStandard,
 }
@@ -395,9 +421,14 @@ impl Redfish for Bmc {
             }
 
             // Check the first boot option
-            if let Some(mac) = boot_interface_mac {
-                let (expected, actual) =
-                    self.get_expected_and_actual_first_boot_option(mac).await?;
+            if let Some(mac_str) = boot_interface_mac {
+                let mac: mac_address::MacAddress =
+                    mac_str.parse().map_err(|e| RedfishError::GenericError {
+                        error: format!("could not parse boot interface MAC `{mac_str}`: {e}"),
+                    })?;
+                let (expected, actual) = self
+                    .get_expected_and_actual_first_boot_option(crate::BootInterfaceRef::Mac(mac))
+                    .await?;
                 if expected.is_none() || expected != actual {
                     diffs.push(MachineSetupDiff {
                         key: "boot_first".to_string(),
@@ -1098,11 +1129,11 @@ impl Redfish for Bmc {
     // option that corresponds to the primary DPU as the first boot option in the list.
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             let expected_boot_option_name: String = self
-                .get_expected_dpu_boot_option_name(boot_interface_mac)
+                .get_expected_dpu_boot_option_name(boot_interface)
                 .await?;
             let boot_order = self.get_boot_order().await?;
             for (idx, boot_option) in boot_order.iter().enumerate() {
@@ -1110,7 +1141,7 @@ impl Redfish for Bmc {
                     if idx == 0 {
                         // Dells will not generate a bios config job below if the boot orders already configured correctly
                         tracing::info!(
-                        "NO-OP: DPU ({boot_interface_mac}) will already be the first netboot option ({expected_boot_option_name}) after reboot"
+                        "NO-OP: DPU ({boot_interface:?}) will already be the first netboot option ({expected_boot_option_name}) after reboot"
                     );
                         return Ok(None);
                     }
@@ -1312,11 +1343,11 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
+                .get_expected_and_actual_first_boot_option(boot_interface)
                 .await?;
             Ok(expected.is_some() && expected == actual)
         })
@@ -2288,7 +2319,7 @@ impl Bmc {
 
     async fn get_dpu_nw_device_function(
         &self,
-        boot_interface_mac_address: &str,
+        boot_interface: crate::BootInterfaceRef<'_>,
     ) -> Result<NetworkDeviceFunction, RedfishError> {
         let chassis = self.get_chassis(self.s.system_id()).await?;
         let na_id = match chassis.network_adapters {
@@ -2327,29 +2358,22 @@ impl Bmc {
                 .and_then(|r| r.try_get())?;
 
             for nw_dev_func in rc_nw_func.members {
-                if let Some(ref ethernet_info) = nw_dev_func.ethernet {
-                    if let Some(ref mac) = ethernet_info.mac_address {
-                        let standardized_mac = mac.to_lowercase();
-                        if standardized_mac == boot_interface_mac_address.to_lowercase() {
-                            return Ok(nw_dev_func);
-                        }
-                    }
+                if nw_dev_func_matches(&nw_dev_func, boot_interface) {
+                    return Ok(nw_dev_func);
                 }
             }
         }
 
         Err(RedfishError::GenericError {
-            error: format!(
-                "could not find network device function for {boot_interface_mac_address}"
-            ),
+            error: format!("could not find network device function for {boot_interface:?}"),
         })
     }
 
     async fn get_dell_nic_info(
         &self,
-        mac_address: &str,
+        boot_interface: crate::BootInterfaceRef<'_>,
     ) -> Result<serde_json::Map<String, Value>, RedfishError> {
-        let nw_device_function = self.get_dpu_nw_device_function(mac_address).await?;
+        let nw_device_function = self.get_dpu_nw_device_function(boot_interface).await?;
 
         let oem = nw_device_function
             .oem
@@ -2379,7 +2403,15 @@ impl Bmc {
 
     // Returns a string like "NIC.Slot.5-1"
     async fn dpu_nic_slot(&self, mac_address: &str) -> Result<String, RedfishError> {
-        let dell_nic_info = self.get_dell_nic_info(mac_address).await?;
+        let mac: mac_address::MacAddress =
+            mac_address
+                .parse()
+                .map_err(|e| RedfishError::GenericError {
+                    error: format!("could not parse boot interface MAC `{mac_address}`: {e}"),
+                })?;
+        let dell_nic_info = self
+            .get_dell_nic_info(crate::BootInterfaceRef::Mac(mac))
+            .await?;
 
         let nic_slot = dell_nic_info
             .get("Id")
@@ -2502,20 +2534,20 @@ impl Bmc {
         Err(RedfishError::GenericError { error: format!("the lifecycle controller is not ready to accept provisioning requests; lc_status: {lc_status}") })
     }
 
-    // get_expected_dpu_boot_option_name assumes that assumes that the HTTP Device One boot option has been enabled
-    // and points to the NIC for the boot interface MAC address. In the future, we can relax the string matching if
+    // get_expected_dpu_boot_option_name assumes that the HTTP Device One boot option has been enabled
+    // and points to the NIC for the boot interface. In the future, we can relax the string matching if
     // we configure other HTTP devices and just match on the NIC's device description.
     async fn get_expected_dpu_boot_option_name(
         &self,
-        boot_interface_mac: &str,
+        boot_interface: crate::BootInterfaceRef<'_>,
     ) -> Result<String, RedfishError> {
-        let dell_nic_info = self.get_dell_nic_info(boot_interface_mac).await?;
+        let dell_nic_info = self.get_dell_nic_info(boot_interface).await?;
 
         let device_description = dell_nic_info
             .get("DeviceDescription")
             .and_then(|device_description| device_description.as_str())
             .ok_or_else(|| RedfishError::GenericError {
-                error: format!("the NIC Device Description for {boot_interface_mac} is missing or not a valid string").to_string(),
+                error: format!("the NIC Device Description for {boot_interface:?} is missing or not a valid string"),
             })?
             .to_string();
 
@@ -2535,14 +2567,14 @@ impl Bmc {
     }
 
     // get_expected_and_actual_first_boot_option assumes that the HTTP Device One boot option has been enabled
-    // and points to the NIC for the boot interface MAC address. In the future, we can relax the string matching if
+    // and points to the NIC for the boot interface. In the future, we can relax the string matching if
     // we configure other HTTP devices and just match on the NIC's device description.
     async fn get_expected_and_actual_first_boot_option(
         &self,
-        boot_interface_mac: &str,
+        boot_interface: crate::BootInterfaceRef<'_>,
     ) -> Result<(Option<String>, Option<String>), RedfishError> {
         let expected_first_boot_option = Some(
-            self.get_expected_dpu_boot_option_name(boot_interface_mac)
+            self.get_expected_dpu_boot_option_name(boot_interface)
                 .await?,
         );
         let boot_order = self.get_boot_order().await?;

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -959,10 +959,12 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        mac_address: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
-            let mac = mac_address.to_string().to_uppercase();
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface)
+                .await?
+                .to_uppercase();
 
             let all = self.get_boot_options().await?;
             let mut boot_ref = None;
@@ -1129,12 +1131,11 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
-                .await?;
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
             Ok(expected.is_some() && expected == actual)
         })
     }

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -988,9 +988,11 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        mac_address: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
+            let mac_address = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let mac_address = mac_address.as_str();
             // Try the OEM NetworkBootOrder path first (older firmware)
             match self.set_boot_order_dpu_first_oem(mac_address).await {
                 Ok(result) => return Ok(result),
@@ -1151,7 +1153,7 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             // Check if Network is first in the boot order
@@ -1165,9 +1167,8 @@ impl Redfish for Bmc {
             }
 
             // Check if the specific MAC address is first in the network boot order
-            let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
-                .await?;
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
             Ok(expected.is_some() && expected == actual)
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,14 +533,16 @@ pub trait Redfish: Send + Sync + 'static {
         id: ODataId,
     ) -> RedfishFuture<'a, Result<Collection, RedfishError>>;
 
-    /// This method will change the boot order so that system will attempt to boot from the dpu first.
-    /// Method will make a platforn specifc best errert to identify the dpu specific boot option.
-    /// It will choose Uefi Http IPv4 option if any.
-    /// If dpu's mac can be passed in as  mac_address to identify the dpu, otherwise method will attempt to find the dpu
-    /// by enumeration NetworkAdapters and associated resources.
+    /// Change the boot order so the system will boot from the chosen NIC first.
+    ///
+    /// `boot_interface` selects the target NIC. A `BootInterfaceRef::Mac` is the
+    /// classic path: the vendor impl looks the NIC up via its BMC enumeration
+    /// by MAC. A `BootInterfaceRef::InterfaceId` is the vendor-native Redfish
+    /// `EthernetInterface.Id` -- used when the caller already knows the
+    /// partition ID.
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        mac_address: &'a str,
+        boot_interface: BootInterfaceRef<'a>,
     ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
 
     fn clear_uefi_password<'a>(
@@ -621,10 +623,11 @@ pub trait Redfish: Send + Sync + 'static {
 
     fn ac_powercycle_supported_by_power(&self) -> bool;
 
-    /// Check if the boot order is configured as we expect (Network boot)
+    /// Is the boot order already configured for `boot_interface`? See
+    /// `set_boot_order_dpu_first` for the variant semantics.
     fn is_boot_order_setup<'a>(
         &'a self,
-        mac_address: &'a str,
+        boot_interface: BootInterfaceRef<'a>,
     ) -> RedfishFuture<'a, Result<bool, RedfishError>>;
 
     /// Returns info about component integrity

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -698,7 +698,7 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(
@@ -900,7 +900,7 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move { Err(RedfishError::NotSupported("not supported".to_string())) })
     }

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -833,7 +833,7 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(
@@ -1008,9 +1008,9 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_boot_order_setup(boot_interface_mac).await })
+        Box::pin(async move { self.s.is_boot_order_setup(boot_interface).await })
     }
 
     fn is_bios_setup<'a>(

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -808,7 +808,7 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(
@@ -941,7 +941,7 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1084,9 +1084,10 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        address: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
+            let address = crate::resolve_boot_interface_mac(self, boot_interface).await?;
             let mac_address = address.replace(':', "").to_uppercase();
             let boot_option_name =
                 format!("{} (MAC:{})", BootOptionName::Http.to_string(), mac_address);
@@ -1236,12 +1237,11 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
-                .await?;
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
             Ok(expected.is_some() && expected == actual)
         })
     }

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -747,7 +747,7 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             // TODO: If a mac_address is given
@@ -889,7 +889,7 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        _mac_address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -911,9 +911,10 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        address: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
+            let address = crate::resolve_boot_interface_mac(self, boot_interface).await?;
             let mut system: ComputerSystem = self.s.get_system().await?;
             let mac_address = address.replace(':', "").to_uppercase();
 
@@ -1200,12 +1201,11 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
-                .await?;
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
             Ok(expected.is_some() && expected == actual)
         })
     }

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -935,7 +935,7 @@ impl Redfish for RedfishStandard {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        _address: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(
@@ -1133,7 +1133,7 @@ impl Redfish for RedfishStandard {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        _boot_interface_mac: &'a str,
+        _boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             Err(RedfishError::NotSupported(

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -892,9 +892,11 @@ impl Redfish for Bmc {
     /// The HTTP adapter will only appear after IPv4HTTPSupport bios setting is enabled and the host rebooted.
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        mac_address: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
+            let mac_address = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let mac_address = mac_address.as_str();
             match self.set_mellanox_first(mac_address).await {
                 Ok(_) => return Ok(None),
                 Err(RedfishError::HTTPErrorCode {
@@ -1098,12 +1100,11 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        boot_interface_mac: &'a str,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            let (expected, actual) = self
-                .get_expected_and_actual_first_boot_option(boot_interface_mac)
-                .await?;
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
             Ok(expected.is_some() && expected == actual)
         })
     }


### PR DESCRIPTION
This supports https://github.com/NVIDIA/infra-controller/issues/2169.

Pulls the `BootInterfaceRef` integration we're now doing in `machine_setup` (from #82) through to the boot-order trait methods, so callers that already know an `EthernetInterface.Id` can pass it straight through instead of having to come up with a MAC.

General idea is, if we have a boot interface ID we know we want to use, we should use it. MAC is a key into an interface ID, but if we already have the interface ID, we can explicitly pass it through.

One use case being if the interface `NetworkDeviceFunction` is set to `Disabled`, we've discovered that the interface doesn't get probed, and doesn't present a MAC, but we already know the interface [partition] ID, so we can set it (which results in the interface adapter getting re-probed and its MAC appearing again).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>