### PR TITLE
Force update lenovo firmware

### DIFF
--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -1756,6 +1756,7 @@ struct UpdateParameters {
     targets: Vec<String>,
     #[serde(rename = "@Redfish.OperationApplyTime")]
     operation_apply_time: String,
+    force_update: bool,
 }
 
 impl UpdateParameters {
@@ -1763,6 +1764,7 @@ impl UpdateParameters {
         Self {
             targets: vec![],
             operation_apply_time: "Immediate".to_string(),
+            force_update: true,
         }
     }
 }


### PR DESCRIPTION
In cases when lenovo machines have a higher version of a firmware component compared to what is in the desired_firmware table, the upgrade silently succeeds as a noop. But since the versions didn't change the machine gets stuck in a loop.

This change will force the update even if the current version is higher.