### PR TITLE
feat: Implement API to set NTP servers

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -1221,6 +1221,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1455,10 +1455,6 @@ impl Redfish for Bmc {
                 return Ok(());
             }
 
-            if self.is_lockdown().await? {
-                return Err(RedfishError::Lockdown);
-            }
-
             let mut attrs = HashMap::from([("NTPConfigGroup.1.NTPEnable", "Enabled")]);
             const NTP_KEYS: [&str; 3] = [
                 "NTPConfigGroup.1.NTP1",

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1445,6 +1445,13 @@ impl Redfish for Bmc {
             Ok(())
         })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1450,7 +1450,45 @@ impl Redfish for Bmc {
         &'a self,
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+        Box::pin(async move {
+            if servers.is_empty() {
+                return Ok(());
+            }
+
+            let mut attrs = HashMap::new();
+            attrs.insert("NTPConfigGroup.1.NTPEnable", "Enabled");
+            if let Some(s1) = servers.first() {
+                attrs.insert("NTPConfigGroup.1.NTP1", s1.as_str());
+            }
+            if let Some(s2) = servers.get(1) {
+                attrs.insert("NTPConfigGroup.1.NTP2", s2.as_str());
+            }
+            if let Some(s3) = servers.get(2) {
+                attrs.insert("NTPConfigGroup.1.NTP3", s3.as_str());
+            }
+
+            // Try standard path first
+            let body = HashMap::from([("Attributes", attrs)]);
+            let manager_id = self.s.manager_id();
+            let standard_url = format!("Managers/{manager_id}/Attributes");
+            match self.s.client.patch(&standard_url, &body).await {
+                Ok(_) => return Ok(()),
+                Err(RedfishError::HTTPErrorCode {
+                    status_code: StatusCode::NOT_FOUND,
+                    ..
+                }) => {
+                    tracing::info!(
+                        "Managers/Attributes not found, using OEM DellAttributes path for NTP server config"
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+
+            // Fallback to OEM DellAttributes path
+            let oem_url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
+            self.s.client.patch(&oem_url, body).await?;
+            Ok(())
+        })
     }
 }
 

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1455,16 +1455,19 @@ impl Redfish for Bmc {
                 return Ok(());
             }
 
-            let mut attrs = HashMap::new();
-            attrs.insert("NTPConfigGroup.1.NTPEnable", "Enabled");
-            if let Some(s1) = servers.first() {
-                attrs.insert("NTPConfigGroup.1.NTP1", s1.as_str());
+            if self.is_lockdown().await? {
+                return Err(RedfishError::Lockdown);
             }
-            if let Some(s2) = servers.get(1) {
-                attrs.insert("NTPConfigGroup.1.NTP2", s2.as_str());
-            }
-            if let Some(s3) = servers.get(2) {
-                attrs.insert("NTPConfigGroup.1.NTP3", s3.as_str());
+
+            let mut attrs = HashMap::from([("NTPConfigGroup.1.NTPEnable", "Enabled")]);
+            const NTP_KEYS: [&str; 3] = [
+                "NTPConfigGroup.1.NTP1",
+                "NTPConfigGroup.1.NTP2",
+                "NTPConfigGroup.1.NTP3",
+            ];
+            for (i, key) in NTP_KEYS.into_iter().enumerate() {
+                // blank unused slots so the set is authoritative
+                attrs.insert(key, servers.get(i).map_or("", String::as_str));
             }
 
             // Try standard path first

--- a/src/delta_powershelf.rs
+++ b/src/delta_powershelf.rs
@@ -857,6 +857,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -1211,7 +1211,21 @@ impl Redfish for Bmc {
         &'a self,
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+        Box::pin(async move {
+            if servers.is_empty() {
+                return Ok(());
+            }
+
+            // iLO supports at most 2 static NTP servers; extra entries are ignored.
+            let static_ntp_servers = vec![
+                servers.first().cloned().unwrap_or_default(),
+                servers.get(1).cloned().unwrap_or_default(),
+            ];
+
+            let url = format!("Managers/{}/DateTime", self.s.manager_id());
+            let body = HashMap::from([("StaticNTPServers", static_ntp_servers)]);
+            self.s.client.patch(&url, body).await.map(|_resp| ())
+        })
     }
 }
 

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -1206,6 +1206,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -1217,6 +1217,12 @@ impl Redfish for Bmc {
             }
 
             // iLO supports at most 2 static NTP servers; extra entries are ignored.
+            if servers.len() > 2 {
+                tracing::warn!(
+                    "iLO supports at most 2 static NTP servers; ignoring {} extra entries",
+                    servers.len() - 2,
+                );
+            }
             let static_ntp_servers = vec![
                 servers.first().cloned().unwrap_or_default(),
                 servers.get(1).cloned().unwrap_or_default(),

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -1239,6 +1239,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,6 +673,12 @@ pub trait Redfish: Send + Sync + 'static {
     // Sets the timezone to UTC
     // Only applicable to Dells
     fn set_utc_timezone<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+
+    // Sets the NTP servers
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -882,6 +882,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -1101,6 +1101,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -1075,6 +1075,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1337,6 +1337,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -1023,6 +1023,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -1276,6 +1276,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1697,7 +1697,7 @@ impl RedfishStandard {
             return Ok(());
         }
 
-        let url = format!("Managers/{}/NetworkProtocol", self.manager_id(),);
+        let url = format!("Managers/{}/NetworkProtocol", self.manager_id());
         let ntp_servers = HashMap::from([(
             "NTP",
             json!({
@@ -1705,7 +1705,15 @@ impl RedfishStandard {
                 "ProtocolEnabled": true,
             }),
         )]);
-        self.client.patch(&url, ntp_servers).await.map(|_resp| ())
+
+        if matches!(
+            self.vendor,
+            Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI)
+        ) {
+            self.client.patch_with_if_match(&url, ntp_servers).await
+        } else {
+            self.client.patch(&url, ntp_servers).await.map(|_resp| ())
+        }
     }
 
     pub async fn reset_manager(

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1250,6 +1250,13 @@ impl Redfish for RedfishStandard {
             Ok(())
         })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl RedfishStandard {
@@ -1682,6 +1689,16 @@ impl RedfishStandard {
         let url = format!("Managers/{}/NetworkProtocol", self.manager_id(),);
         let (_status_code, body) = self.client.get(&url).await?;
         Ok(body)
+    }
+
+    pub async fn set_manager_ntp_servers(&self, servers: &[String]) -> Result<(), RedfishError> {
+        if servers.is_empty() {
+            return Ok(());
+        }
+
+        let url = format!("Managers/{}/NetworkProtocol", self.manager_id(),);
+        let ntp_servers = HashMap::from([("NTP", json!({ "NTPServers": servers }))]);
+        self.client.patch(&url, ntp_servers).await.map(|_resp| ())
     }
 
     pub async fn reset_manager(

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1691,13 +1691,20 @@ impl RedfishStandard {
         Ok(body)
     }
 
+    /// Set NTP servers via the standard ManagerNetworkProtocol resource.
     pub async fn set_manager_ntp_servers(&self, servers: &[String]) -> Result<(), RedfishError> {
         if servers.is_empty() {
             return Ok(());
         }
 
         let url = format!("Managers/{}/NetworkProtocol", self.manager_id(),);
-        let ntp_servers = HashMap::from([("NTP", json!({ "NTPServers": servers }))]);
+        let ntp_servers = HashMap::from([(
+            "NTP",
+            json!({
+                "NTPServers": servers,
+                "ProtocolEnabled": true,
+            }),
+        )]);
         self.client.patch(&url, ntp_servers).await.map(|_resp| ())
     }
 

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -1175,6 +1175,13 @@ impl Redfish for Bmc {
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
 }
 
 impl Bmc {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -1180,7 +1180,12 @@ impl Redfish for Bmc {
         &'a self,
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+        Box::pin(async move {
+            if self.get_syslockdown().await? {
+                return Err(RedfishError::Lockdown);
+            }
+            self.s.set_manager_ntp_servers(servers).await
+        })
     }
 }
 

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -1180,12 +1180,7 @@ impl Redfish for Bmc {
         &'a self,
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            if self.get_syslockdown().await? {
-                return Err(RedfishError::Lockdown);
-            }
-            self.s.set_manager_ntp_servers(servers).await
-        })
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 


### PR DESCRIPTION
Added a new Redfish API method `set_ntp_servers` that configures a list of NTP servers of the BMC.

See [issue #548](https://github.com/NVIDIA/infra-controller/issues/548#issuecomment-4298763067).