### PR TITLE
chore: add a failed value to the JobState enum to capture when a job enters a failure state

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1074,6 +1074,15 @@ impl Redfish for Bmc {
             let job_state_value = jsonmap::get_str(&body, "JobState", &url)?;
 
             let job_state = match JobState::from_str(job_state_value) {
+                JobState::Unknown => {
+                    tracing::warn!(
+                        bmc_ip = %self.s.client.host(),
+                        job_id = %job_id,
+                        raw_job_state = %job_state_value,
+                        "Unrecognized Redfish JobState; mapping to JobState::Unknown"
+                    );
+                    JobState::Unknown
+                }
                 JobState::Scheduled => {
                     let message_value = jsonmap::get_str(&body, "Message", &url)?;
                     match message_value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,16 +876,27 @@ pub enum JobState {
     Running,
     Completed,
     CompletedWithErrors,
+    Failed,
     Unknown,
 }
 
 impl JobState {
+    /// Returns `true` when the job is in a terminal failure state and will not
+    /// progress to completion.
+    pub fn is_error_state(&self) -> bool {
+        matches!(
+            self,
+            JobState::ScheduledWithErrors | JobState::CompletedWithErrors | JobState::Failed
+        )
+    }
+
     fn from_str(s: &str) -> JobState {
         match s {
             "Scheduled" => JobState::Scheduled,
             "Running" => JobState::Running,
             "Completed" => JobState::Completed,
             "CompletedWithErrors" => JobState::CompletedWithErrors,
+            "Failed" => JobState::Failed,
             _ => JobState::Unknown,
         }
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -296,6 +296,11 @@ impl RedfishHttpClient {
         self.endpoint.user.is_none()
     }
 
+    /// Returns the hostname or IP address of the BMC this client targets.
+    pub fn host(&self) -> &str {
+        &self.endpoint.host
+    }
+
     pub async fn get<T>(&self, api: &str) -> Result<(StatusCode, T), RedfishError>
     where
         T: DeserializeOwned + ::std::fmt::Debug,


### PR DESCRIPTION
chore: add a failed value to the JobState enum to capture when a job enters a failure state. log when we encounter an unknown job enum