### PR TITLE
feat(lpu): track optional ComputerSystem part_number

### DIFF
--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -185,8 +185,8 @@ pub struct ComputerSystem {
     pub manufacturer: Option<String>,
     pub model: Option<String>,
     pub oem: Option<SystemExtensions>,
-    // Dell: String. Lenovo: always null
-    //pub part_number: String,
+    // Dell: String. Lenovo: null
+    pub part_number: Option<String>,
     #[serde(default)]
     pub power_state: PowerState,
     pub processor_summary: Option<SystemProcessors>,
@@ -379,6 +379,7 @@ mod test {
         let result: super::ComputerSystem = serde_json::from_str(data).unwrap();
         assert_eq!(result.power_state, crate::PowerState::On);
         assert_eq!(result.processor_summary.unwrap().count, Some(2));
+        assert_eq!(result.part_number.as_deref(), Some("0H28RRA06"));
     }
 
     #[test]
@@ -432,6 +433,7 @@ mod test {
             Some(3816)
         );
         assert_eq!(result.processor_summary.unwrap().count, Some(2));
+        assert_eq!(result.part_number, None);
     }
 
     #[test]


### PR DESCRIPTION
# Executive Summary
* `ComputerSystem.part_number` was commented out in ad1b4d41ab22eb17d85a7bf142b0ddc41e8eccaa because Lenovo systems reported null for this field.


## Summary

Expose `ComputerSystem.part_number` as an optional field so callers can read part numbers while correctly handling Lenovo systems that return `null`.

## Root cause

The property had been commented out because the original required `String` type could not deserialize Lenovo's `null` value.

## Validation

- `mise exec -- cargo test model::system`
- `mise exec -- cargo fmt --check`
- `git diff --check`
